### PR TITLE
Version 1.4.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.4.0+{build}
+version: 1.4.1+{build}
 skip_tags: true
 image:
 - Visual Studio 2017

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Guard
 
-[![NuGet](https://img.shields.io/nuget/v/Dawn.Guard.svg?style=flat)](https://www.nuget.org/packages/Dawn.Guard/)
-[![Build](https://ci.appveyor.com/api/projects/status/add0vx8i2yacvprf/branch/dev?svg=true)](https://ci.appveyor.com/project/safak/guard/branch/dev)
-[![Tests](https://img.shields.io/appveyor/tests/safak/guard/dev.svg)](https://ci.appveyor.com/project/safak/guard/branch/dev)
-[![Coverage](https://codecov.io/gh/safakgur/guard/branch/dev/graph/badge.svg)](https://codecov.io/gh/safakgur/guard/branch/dev)
-
 ![Logo](media/guard-64.png)
 
 Guard is a fluent argument validation library that is intuitive, fast and extensible.
+
+[![NuGet](https://img.shields.io/nuget/v/Dawn.Guard.svg?style=flat)](https://www.nuget.org/packages/Dawn.Guard/)
+[![Windows/Linux](https://ci.appveyor.com/api/projects/status/add0vx8i2yacvprf/branch/dev?svg=true)](https://ci.appveyor.com/project/safak/guard/branch/dev)
+[![macOS](https://travis-ci.org/safakgur/guard.svg?branch=dev)](https://travis-ci.org/safakgur/guard)
+[![Tests](https://img.shields.io/appveyor/tests/safak/guard/dev.svg)](https://ci.appveyor.com/project/safak/guard/branch/dev)
+[![Coverage](https://codecov.io/gh/safakgur/guard/branch/dev/graph/badge.svg)](https://codecov.io/gh/safakgur/guard/branch/dev)
 
 * [Introduction](#introduction)
 * [What's Wrong with Vanilla?](#whats-wrong-with-vanilla)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ public Person(string firstName, string lastName)
 
 If this looks like too much allocations to you, fear not. The arguments are read-only structs that
 are passed by reference, and there are ways other than member expressions to initialize them.
-See the [design decisions][1] for details.
+See the [design decisions](#design-decisions) for details.
 
 ## What's Wrong with Vanilla?
 

--- a/build/README.md
+++ b/build/README.md
@@ -47,5 +47,11 @@ Options
 The build and test scripts assume that `dotnet` is in PATH when `-NoInstall` is set and the SDKs
 are not found in the "artifacts/dotnet".
 
+**Apveyor Script**
+
+[appveyor.ps1][3] is executed on AppVeyor builds. It builds and tests the library, then uploads the
+coverage results to CodeCov.
+
 [1]: https://docs.microsoft.com/powershell/scripting/setup/installing-powershell-core-on-linux
 [2]: https://github.com/tonerdo/coverlet
+[3]: appveyor.ps1

--- a/build/appveyor.ps1
+++ b/build/appveyor.ps1
@@ -1,14 +1,19 @@
+$TestResult
 IF ($IsWindows -or $env:OS -like "Windows*")
 {
     & $PSScriptRoot/test.ps1 -NoInstall -Configuration CI -Coverage
+    $TestResult = $lastexitcode
 
-	choco install codecov --no-progress
+    choco install codecov --no-progress
     IF ($lastexitcode -eq 0)
     {
-	    codecov -f $PSScriptRoot/../artifacts/coverage.xml
+        codecov -f $PSScriptRoot/../artifacts/coverage.xml
     }
 }
 ELSE
 {
     & $PSScriptRoot/test.ps1 -NoInstall -Configuration Release
+    $TestResult = $lastexitcode
 }
+
+exit $TestResult

--- a/src/Guard.Argument.cs
+++ b/src/Guard.Argument.cs
@@ -11,8 +11,7 @@
     public static partial class Guard
     {
         /// <summary>
-        ///     Returns an object that can be used to assert preconditions for the specified
-        ///     method argument.
+        ///     Returns an object that can be used to assert preconditions for the specified method argument.
         /// </summary>
         /// <typeparam name="T">The type of the method argument.</typeparam>
         /// <param name="e">An expression that specifies a method argument.</param>
@@ -21,9 +20,7 @@
         ///     messages of failed validations.
         /// </param>
         /// <returns>An object used for asserting preconditions.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="e" /> is <c>null</c>.
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="e" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="e" /> is not a <see cref="MemberExpression" />.
         /// </exception>
@@ -46,7 +43,7 @@
         /// <param name="value">The value of the method argument.</param>
         /// <param name="name">
         ///     <para>
-        ///         The name of the method argument. Use the <c>nameof</c> operator (<c>Nameof</c>
+        ///         The name of the method argument. Use the <c>nameof</c> operator ( <c>Nameof</c>
         ///         in Visual Basic) where possible.
         ///     </para>
         ///     <para>
@@ -78,7 +75,7 @@
             private readonly string name;
 
             /// <summary>
-            ///     Initializes a new instance of the <see cref="ArgumentInfo{T} "/> struct.
+            ///     Initializes a new instance of the <see cref="ArgumentInfo{T} " /> struct.
             /// </summary>
             /// <param name="value">The value of the method argument.</param>
             /// <param name="name">The name of the method argument.</param>
@@ -112,17 +109,15 @@
             public bool Modified { get; }
 
             /// <summary>
-            ///     Gets a value indicating whether sensitive information may be used to validate
-            ///     the argument. If <c>true</c>, exception messages provide less information about
-            ///     the validation parameters.
+            ///     Gets a value indicating whether sensitive information may be used to validate the
+            ///     argument. If <c>true</c>, exception messages provide less information about the
+            ///     validation parameters.
             /// </summary>
             public bool Secure { get; }
 
-            /// <summary>
-            ///     Gets how the layout is displayed in the debugger variable windows.
-            /// </summary>
+            /// <summary>Gets how the layout is displayed in the debugger variable windows.</summary>
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-            private string DebuggerDisplay
+            internal string DebuggerDisplay
             {
                 get
                 {
@@ -140,8 +135,7 @@
 
             /// <summary>Determines whether the argument value is not <c>null</c>.</summary>
             /// <returns>
-            ///     <c>true</c>, if <see cref="Value" /> is not <c>null</c>; otherwise,
-            ///     <c>false</c>.
+            ///     <c>true</c>, if <see cref="Value" /> is not <c>null</c>; otherwise, <c>false</c>.
             /// </returns>
             [DebuggerStepThrough]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Guard.Argument.cs
+++ b/src/Guard.Argument.cs
@@ -5,6 +5,7 @@
     using System.Linq.Expressions;
     using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
+    using JetBrains.Annotations;
 
     /// <summary>Validates argument preconditions.</summary>
     /// <content>Contains the argument initialization methods.</content>
@@ -21,9 +22,8 @@
         /// </param>
         /// <returns>An object used for asserting preconditions.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="e" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="e" /> is not a <see cref="MemberExpression" />.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="e" /> is not a <see cref="MemberExpression" />.</exception>
+        [ContractAnnotation("e:null => halt")]
         [DebuggerStepThrough]
         public static ArgumentInfo<T> Argument<T>(Expression<Func<T>> e, bool secure = false)
         {
@@ -57,7 +57,8 @@
         /// </param>
         /// <returns>An object used for asserting preconditions.</returns>
         [DebuggerStepThrough]
-        public static ArgumentInfo<T> Argument<T>(T value, string name = null, bool secure = false)
+        public static ArgumentInfo<T> Argument<T>(
+            T value, [InvokerParameterName] string name = null, bool secure = false)
             => new ArgumentInfo<T>(value, name, secure: secure);
 
         /// <summary>Represents a method argument.</summary>
@@ -66,9 +67,7 @@
         [StructLayout(LayoutKind.Auto)]
         public readonly partial struct ArgumentInfo<T>
         {
-            /// <summary>
-            ///     The default name for the arguments of type <typeparamref name="T" />.
-            /// </summary>
+            /// <summary>The default name for the arguments of type <typeparamref name="T" />.</summary>
             private static readonly string defaultName = $"The {typeof(T)} argument";
 
             /// <summary>The argument name.</summary>
@@ -88,7 +87,11 @@
             ///     messages of failed validations.
             /// </param>
             [DebuggerStepThrough]
-            public ArgumentInfo(T value, string name, bool modified = false, bool secure = false)
+            public ArgumentInfo(
+                T value,
+                [InvokerParameterName] string name,
+                bool modified = false,
+                bool secure = false)
             {
                 this.Value = value;
                 this.name = name;

--- a/src/Guard.Boolean.cs
+++ b/src/Guard.Boolean.cs
@@ -1,6 +1,7 @@
 ﻿namespace Dawn
 {
     using System;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="bool" /> arguments.</content>
     public static partial class Guard
@@ -8,13 +9,11 @@
         /// <summary>Requires the boolean argument to be <c>true</c>.</summary>
         /// <param name="argument">The boolean argument.</param>
         /// <param name="message">
-        ///     The message of the exception that will be thrown
-        ///     if the precondition is not satisfied.
+        ///     The message of the exception that will be thrown if the precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <c>false</c>.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> value is <c>false</c>.</exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<bool> True(
             in this ArgumentInfo<bool> argument, string message = null)
         {
@@ -27,19 +26,14 @@
             return ref argument;
         }
 
-        /// <summary>
-        ///     Requires the nullable boolean argument
-        ///     to be <c>true</c> or <c>null</c>.
-        /// </summary>
+        /// <summary>Requires the nullable boolean argument to be <c>true</c> or <c>null</c>.</summary>
         /// <param name="argument">The boolean argument.</param>
         /// <param name="message">
-        ///     The message of the exception that will be thrown
-        ///     if the precondition is not satisfied.
+        ///     The message of the exception that will be thrown if the precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <c>false</c>.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> value is <c>false</c>.</exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<bool?> True(
             in this ArgumentInfo<bool?> argument, string message = null)
         {
@@ -55,13 +49,11 @@
         /// <summary>Requires the boolean argument to be <c>false</c>.</summary>
         /// <param name="argument">The boolean argument.</param>
         /// <param name="message">
-        ///     The message of the exception that will be thrown
-        ///     if the precondition is not satisfied.
+        ///     The message of the exception that will be thrown if the precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <c>true</c>.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> value is <c>true</c>.</exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<bool> False(
             in this ArgumentInfo<bool> argument, string message = null)
         {
@@ -74,19 +66,14 @@
             return ref argument;
         }
 
-        /// <summary>
-        ///     Requires the nullable boolean argument
-        ///     to be <c>false</c> or <c>null</c>.
-        /// </summary>
+        /// <summary>Requires the nullable boolean argument to be <c>false</c> or <c>null</c>.</summary>
         /// <param name="argument">The boolean argument.</param>
         /// <param name="message">
-        ///     The message of the exception that will be thrown
-        ///     if the precondition is not satisfied.
+        ///     The message of the exception that will be thrown if the precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <c>true</c>.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> value is <c>true</c>.</exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<bool?> False(
             in this ArgumentInfo<bool?> argument, string message = null)
         {

--- a/src/Guard.Double.cs
+++ b/src/Guard.Double.cs
@@ -1,13 +1,14 @@
 ﻿namespace Dawn
 {
     using System;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="double" /> arguments.</content>
     public static partial class Guard
     {
         /// <summary>
-        ///     Requires the double-precision floating-point argument to have a value that is
-        ///     "not a number" (<see cref="double.NaN" />).
+        ///     Requires the double-precision floating-point argument to have a value that is "not a
+        ///     number" ( <see cref="double.NaN" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -16,13 +17,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not <see cref="double.NaN" />, and the
-        ///     argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not <see cref="double.NaN" />, and the argument
+        ///     is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <see cref="double.NaN" />, and the
-        ///     argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not <see cref="double.NaN" />, and the argument
+        ///     is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double> NaN(
             in this ArgumentInfo<double> argument, Func<double, string> message = null)
         {
@@ -39,7 +41,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is either
-        ///     <c>null</c> or "not a number" (<see cref="double.NaN" />).
+        ///     <c>null</c> or "not a number" ( <see cref="double.NaN" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -56,12 +58,12 @@
         ///     <see cref="double.NaN" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double?> NaN(
             in this ArgumentInfo<double?> argument, Func<double?, string> message = null)
         {
@@ -82,7 +84,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is not
-        ///     "not a number" (<see cref="double.NaN" />).
+        ///     "not a number" ( <see cref="double.NaN" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -97,6 +99,7 @@
         ///     <paramref name="argument" /> value is <see cref="double.NaN" />, and the argument is
         ///     modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double> NotNaN(
             in this ArgumentInfo<double> argument, string message = null)
         {
@@ -113,7 +116,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is not
-        ///     "not a number" (<see cref="double.NaN" />).
+        ///     "not a number" ( <see cref="double.NaN" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -128,6 +131,7 @@
         ///     <paramref name="argument" /> value is <see cref="double.NaN" />, and the argument is
         ///     modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double?> NotNaN(
             in this ArgumentInfo<double?> argument, string message = null)
         {
@@ -148,8 +152,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is either
-        ///     positive infinity (<see cref="double.PositiveInfinity" />) or negative infinity
-        ///     (<see cref="double.NegativeInfinity" />).
+        ///     positive infinity ( <see cref="double.PositiveInfinity" />) or negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -159,14 +162,14 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="argument" /> value is neither <see cref="double.PositiveInfinity" />
-        ///     nor <see cref="double.NegativeInfinity" />, and the argument is not modified since
-        ///     it is initialized.
+        ///     nor <see cref="double.NegativeInfinity" />, and the argument is not modified since it
+        ///     is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is neither <see cref="double.PositiveInfinity" />
-        ///     nor <see cref="double.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     nor <see cref="double.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double> Infinity(
             in this ArgumentInfo<double> argument, Func<double, string> message = null)
         {
@@ -183,8 +186,8 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is
-        ///     <c>null</c>, positive infinity (<see cref="double.PositiveInfinity" />) or negative
-        ///     infinity (<see cref="double.NegativeInfinity" />).
+        ///     <c>null</c>, positive infinity ( <see cref="double.PositiveInfinity" />) or negative
+        ///     infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -194,21 +197,21 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="argument" /> value is not <c>null</c>, not
-        ///     <see cref="double.PositiveInfinity" /> and not <see cref="double.NegativeInfinity" />,
-        ///     and the argument is not modified since it is initialized.
+        ///     <see cref="double.PositiveInfinity" /> and not
+        ///     <see cref="double.NegativeInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is not <c>null</c>, not
-        ///     <see cref="double.PositiveInfinity" /> and not <see cref="double.NegativeInfinity" />,
-        ///     and the argument is modified after its initialization.
+        ///     <see cref="double.PositiveInfinity" /> and not
+        ///     <see cref="double.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double?> Infinity(
             in this ArgumentInfo<double?> argument, Func<double?, string> message = null)
         {
@@ -228,9 +231,8 @@
         }
 
         /// <summary>
-        ///     Requires the double-precision floating-point argument to have a value that is
-        ///     neither positive infinity (<see cref="double.PositiveInfinity" />) nor negative
-        ///     infinity (<see cref="double.NegativeInfinity" />).
+        ///     Requires the double-precision floating-point argument to have a value that is neither
+        ///     positive infinity ( <see cref="double.PositiveInfinity" />) nor negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -244,9 +246,9 @@
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is either <see cref="double.PositiveInfinity" />
-        ///     or <see cref="double.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     or <see cref="double.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         [Obsolete("Use the NotInfinity overload that accepts the message as a `Func<double, string>`.")]
         public static ref readonly ArgumentInfo<double> NotInfinity(
             in this ArgumentInfo<double> argument, string message)
@@ -263,9 +265,8 @@
         }
 
         /// <summary>
-        ///     Requires the double-precision floating-point argument to have a value that is
-        ///     neither positive infinity (<see cref="double.PositiveInfinity" />) nor negative
-        ///     infinity (<see cref="double.NegativeInfinity" />).
+        ///     Requires the double-precision floating-point argument to have a value that is neither
+        ///     positive infinity ( <see cref="double.PositiveInfinity" />) nor negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -280,9 +281,9 @@
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is either <see cref="double.PositiveInfinity" />
-        ///     or <see cref="double.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     or <see cref="double.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double> NotInfinity(
             in this ArgumentInfo<double> argument, Func<double, string> message = null)
         {
@@ -298,9 +299,8 @@
         }
 
         /// <summary>
-        ///     Requires the double-precision floating-point argument to have a value that is
-        ///     neither positive infinity (<see cref="double.PositiveInfinity" />) nor negative
-        ///     infinity (<see cref="double.NegativeInfinity" />).
+        ///     Requires the double-precision floating-point argument to have a value that is neither
+        ///     positive infinity ( <see cref="double.PositiveInfinity" />) nor negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -314,9 +314,9 @@
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is either <see cref="double.PositiveInfinity" />
-        ///     or <see cref="double.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     or <see cref="double.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         [Obsolete("Use the NotInfinity overload that accepts the message as a `Func<double?, string>`.")]
         public static ref readonly ArgumentInfo<double?> NotInfinity(
             in this ArgumentInfo<double?> argument, string message)
@@ -333,9 +333,8 @@
         }
 
         /// <summary>
-        ///     Requires the double-precision floating-point argument to have a value that is
-        ///     neither positive infinity (<see cref="double.PositiveInfinity" />) nor negative
-        ///     infinity (<see cref="double.NegativeInfinity" />).
+        ///     Requires the double-precision floating-point argument to have a value that is neither
+        ///     positive infinity ( <see cref="double.PositiveInfinity" />) nor negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -350,16 +349,15 @@
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is either <see cref="double.PositiveInfinity" />
-        ///     or <see cref="double.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     or <see cref="double.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double?> NotInfinity(
             in this ArgumentInfo<double?> argument, Func<double?, string> message = null)
         {
@@ -380,7 +378,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is
-        ///     positive infinity (<see cref="double.PositiveInfinity" />).
+        ///     positive infinity ( <see cref="double.PositiveInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -389,13 +387,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not <see cref="double.PositiveInfinity" />,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not <see cref="double.PositiveInfinity" />, and
+        ///     the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <see cref="double.PositiveInfinity" />,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not <see cref="double.PositiveInfinity" />, and
+        ///     the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double> PositiveInfinity(
             in this ArgumentInfo<double> argument, Func<double, string> message = null)
         {
@@ -412,7 +411,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is either
-        ///     <c>null</c> or positive infinity (<see cref="double.PositiveInfinity" />).
+        ///     <c>null</c> or positive infinity ( <see cref="double.PositiveInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -422,21 +421,19 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor
-        ///     <see cref="double.PositiveInfinity" />, and the argument is not modified
-        ///     since it is initialized.
+        ///     <see cref="double.PositiveInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor
-        ///     <see cref="double.PositiveInfinity" />, and the argument is modified
-        ///     after its initialization.
+        ///     <see cref="double.PositiveInfinity" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double?> PositiveInfinity(
             in this ArgumentInfo<double?> argument, Func<double?, string> message = null)
         {
@@ -457,7 +454,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is not
-        ///     positive infinity (<see cref="double.PositiveInfinity" />).
+        ///     positive infinity ( <see cref="double.PositiveInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -465,13 +462,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is <see cref="double.PositiveInfinity" />, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <see cref="double.PositiveInfinity" />, and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <see cref="double.PositiveInfinity" />, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <see cref="double.PositiveInfinity" />, and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double> NotPositiveInfinity(
             in this ArgumentInfo<double> argument, string message = null)
         {
@@ -488,7 +486,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is not
-        ///     positive infinity (<see cref="double.PositiveInfinity" />).
+        ///     positive infinity ( <see cref="double.PositiveInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -496,13 +494,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is <see cref="double.PositiveInfinity" />, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <see cref="double.PositiveInfinity" />, and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <see cref="double.PositiveInfinity" />, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <see cref="double.PositiveInfinity" />, and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double?> NotPositiveInfinity(
             in this ArgumentInfo<double?> argument, string message = null)
         {
@@ -523,7 +522,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is
-        ///     negative infinity (<see cref="double.NegativeInfinity" />).
+        ///     negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -532,13 +531,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not <see cref="double.NegativeInfinity" />,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not <see cref="double.NegativeInfinity" />, and
+        ///     the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <see cref="double.NegativeInfinity" />,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not <see cref="double.NegativeInfinity" />, and
+        ///     the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double> NegativeInfinity(
             in this ArgumentInfo<double> argument, Func<double, string> message = null)
         {
@@ -555,7 +555,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is either
-        ///     <c>null</c> or negative infinity (<see cref="double.NegativeInfinity" />).
+        ///     <c>null</c> or negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -565,21 +565,19 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor
-        ///     <see cref="double.NegativeInfinity" />, and the argument is not
-        ///     modified since it is initialized.
+        ///     <see cref="double.NegativeInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor
-        ///     <see cref="double.NegativeInfinity" />, and the argument is
-        ///     modified after its initialization.
+        ///     <see cref="double.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double?> NegativeInfinity(
             in this ArgumentInfo<double?> argument, Func<double?, string> message = null)
         {
@@ -600,7 +598,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is not
-        ///     negative infinity (<see cref="double.NegativeInfinity" />).
+        ///     negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -608,13 +606,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is <see cref="double.NegativeInfinity" />, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <see cref="double.NegativeInfinity" />, and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <see cref="double.NegativeInfinity" />, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <see cref="double.NegativeInfinity" />, and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double> NotNegativeInfinity(
             in this ArgumentInfo<double> argument, string message = null)
         {
@@ -631,7 +630,7 @@
 
         /// <summary>
         ///     Requires the double-precision floating-point argument to have a value that is not
-        ///     negative infinity (<see cref="double.NegativeInfinity" />).
+        ///     negative infinity ( <see cref="double.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -639,13 +638,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is <see cref="double.NegativeInfinity" />, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <see cref="double.NegativeInfinity" />, and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <see cref="double.NegativeInfinity" />, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <see cref="double.NegativeInfinity" />, and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<double?> NotNegativeInfinity(
             in this ArgumentInfo<double?> argument, string message = null)
         {

--- a/src/Guard.Email.cs
+++ b/src/Guard.Email.cs
@@ -1,9 +1,11 @@
 ﻿#if !NETSTANDARD1_0
+
 namespace Dawn
 {
     using System;
     using System.Collections.Generic;
     using System.Net.Mail;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="MailAddress" /> arguments.</content>
     public static partial class Guard
@@ -19,6 +21,7 @@ namespace Dawn
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value's host is not <paramref name="host" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<MailAddress> HasHost(
             in this ArgumentInfo<MailAddress> argument,
             string host,
@@ -45,6 +48,7 @@ namespace Dawn
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value's host is <paramref name="host" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<MailAddress> DoesNotHaveHost(
             in this ArgumentInfo<MailAddress> argument,
             string host,
@@ -63,18 +67,16 @@ namespace Dawn
         /// <summary>Requires the argument value to have one of the specified hosts.</summary>
         /// <typeparam name="TCollection">The type of the hosts collection.</typeparam>
         /// <param name="argument">The email address argument.</param>
-        /// <param name="hosts">
-        ///     The hosts that the argument value is required to have one of.
-        /// </param>
+        /// <param name="hosts">The hosts that the argument value is required to have one of.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value's host is not specified in
-        ///     <paramref name="hosts" />.
+        ///     <paramref name="argument" /> value's host is not specified in <paramref name="hosts" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<MailAddress> HostIn<TCollection>(
             in this ArgumentInfo<MailAddress> argument,
             TCollection hosts,
@@ -94,9 +96,7 @@ namespace Dawn
         /// <summary>Requires the argument value to have none of the specified hosts.</summary>
         /// <typeparam name="TCollection">The type of the hosts collection.</typeparam>
         /// <param name="argument">The email address argument.</param>
-        /// <param name="hosts">
-        ///     The hosts that the argument value is required not to have any.
-        /// </param>
+        /// <param name="hosts">The hosts that the argument value is required not to have any.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
@@ -105,6 +105,7 @@ namespace Dawn
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value's host is specified in <paramref name="hosts" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<MailAddress> HostNotIn<TCollection>(
             in this ArgumentInfo<MailAddress> argument,
             TCollection hosts,
@@ -131,6 +132,7 @@ namespace Dawn
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value does not have a display name specified.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<MailAddress> HasDisplayName(
             in this ArgumentInfo<MailAddress> argument, Func<MailAddress, string> message = null)
         {
@@ -153,6 +155,7 @@ namespace Dawn
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value has a display name specified.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<MailAddress> DoesNotHaveDisplayName(
             in this ArgumentInfo<MailAddress> argument, Func<MailAddress, string> message = null)
         {
@@ -166,4 +169,5 @@ namespace Dawn
         }
     }
 }
+
 #endif

--- a/src/Guard.Enums.Legacy.cs
+++ b/src/Guard.Enums.Legacy.cs
@@ -2,23 +2,21 @@
 {
     using System;
     using System.Collections.Generic;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="System.Enum" /> arguments.</content>
     public static partial class Guard
     {
-        #region Methods
-
         /// <summary>Exposes the enum preconditions.</summary>
         /// <typeparam name="T">Type of the enum argument.</typeparam>
         /// <param name="argument">The enum argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the argument type is not an enum.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     argument type is not an enum.
         /// </param>
         /// <returns>A new <see cref="EnumArgumentInfo{T}" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <typeparamref name="T" /> is not an enum.
-        /// </exception>
+        /// <exception cref="ArgumentException"><typeparamref name="T" /> is not an enum.</exception>
+        [AssertionMethod]
         [Obsolete("Use the enum preconditions directly, e.g. `arg.Defined()` instead of `arg.Enum().Defined()`.")]
         public static EnumArgumentInfo<T> Enum<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message = null)
@@ -37,13 +35,12 @@
         /// <typeparam name="T">Type of the enum argument.</typeparam>
         /// <param name="argument">The enum argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the argument type is not an enum.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     argument type is not an enum.
         /// </param>
         /// <returns>A new <see cref="NullableEnumArgumentInfo{T}" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <typeparamref name="T" /> is not an enum.
-        /// </exception>
+        /// <exception cref="ArgumentException"><typeparamref name="T" /> is not an enum.</exception>
+        [AssertionMethod]
         [Obsolete("Use the enum preconditions directly, e.g. `arg.Defined()` instead of `arg.Enum().Defined()`.")]
         public static NullableEnumArgumentInfo<T> Enum<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message = null)
@@ -58,18 +55,12 @@
             return new NullableEnumArgumentInfo<T>(argument);
         }
 
-        #endregion Methods
-
-        #region Structs
-
         /// <summary>Represents a method argument with an enumeration value.</summary>
         /// <typeparam name="T">The type of the enum.</typeparam>
         [Obsolete("Use the enum preconditions directly, e.g. `arg.Defined()` instead of `arg.Enum().Defined()`.")]
         public readonly struct EnumArgumentInfo<T>
             where T : struct, IComparable, IFormattable
         {
-            #region Constructors
-
             /// <summary>
             ///     Initializes a new instance of the <see cref="EnumArgumentInfo{T}" /> struct.
             /// </summary>
@@ -77,16 +68,8 @@
             internal EnumArgumentInfo(ArgumentInfo<T> argument)
                 => this.Argument = argument;
 
-            #endregion Constructors
-
-            #region Properties
-
             /// <summary>Gets the original argument.</summary>
             public ArgumentInfo<T> Argument { get; }
-
-            #endregion Properties
-
-            #region Operators
 
             /// <summary>Gets the value of an enum argument.</summary>
             /// <param name="argument">The argument whose value to return.</param>
@@ -94,23 +77,18 @@
             public static implicit operator T(EnumArgumentInfo<T> argument)
                 => argument.Argument.Value;
 
-            #endregion Operators
-
-            #region Methods
-
             /// <summary>
-            ///     Requires the enum argument to be a defined member
-            ///     of the enum type <typeparamref name="T" />.
+            ///     Requires the enum argument to be a defined member of the enum type <typeparamref name="T" />.
             /// </summary>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> value is not a defined member
-            ///     of the enum type <typeparamref name="T" />.
+            ///     <see cref="Argument" /> value is not a defined member of the enum type <typeparamref name="T" />.
             /// </exception>
             /// <returns>The current instance.</returns>
+            [AssertionMethod]
             public EnumArgumentInfo<T> Defined(Func<T, string> message = null)
             {
                 if (!EnumInfo<T>.Values.Contains(this.Argument.Value))
@@ -124,13 +102,14 @@
 
             /// <summary>Requires the enum argument to have none of its bits set.</summary>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
             ///     <see cref="Argument" /> value has one or more of its bits set.
             /// </exception>
+            [AssertionMethod]
             public EnumArgumentInfo<T> None(Func<T, string> message = null)
             {
                 if (!EqualityComparer<T>.Default.Equals(this.Argument.Value, default))
@@ -142,17 +121,16 @@
                 return this;
             }
 
-            /// <summary>
-            ///     Requires the enum argument to have at least one of its bits set.
-            /// </summary>
+            /// <summary>Requires the enum argument to have at least one of its bits set.</summary>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
             ///     <see cref="Argument" /> value has none of its bits set.
             /// </exception>
+            [AssertionMethod]
             public EnumArgumentInfo<T> NotNone(Func<T, string> message = null)
             {
                 if (EqualityComparer<T>.Default.Equals(this.Argument.Value, default))
@@ -167,14 +145,14 @@
             /// <summary>Requires the enum argument to have the specified value.</summary>
             /// <param name="other">The value to compare the argument value to.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> value is different
-            ///     than <paramref name="other" />.
+            ///     <see cref="Argument" /> value is different than <paramref name="other" />.
             /// </exception>
+            [AssertionMethod]
             public EnumArgumentInfo<T> Equal(T other, Func<T, T, string> message = null)
             {
                 if (!EqualityComparer<T>.Default.Equals(this.Argument.Value, other))
@@ -187,18 +165,18 @@
             }
 
             /// <summary>
-            ///     Requires the enum argument to have a value
-            ///     is different than the specified value.
+            ///     Requires the enum argument to have a value is different than the specified value.
             /// </summary>
             /// <param name="other">The value to compare the argument value to.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
             ///     <see cref="Argument" /> value is equal to <paramref name="other" />.
             /// </exception>
+            [AssertionMethod]
             public EnumArgumentInfo<T> NotEqual(T other, Func<T, string> message = null)
             {
                 if (EqualityComparer<T>.Default.Equals(this.Argument.Value, other))
@@ -210,20 +188,18 @@
                 return this;
             }
 
-            /// <summary>
-            ///     Requires the enum argument to have
-            ///     the specified flag bits set.
-            /// </summary>
+            /// <summary>Requires the enum argument to have the specified flag bits set.</summary>
             /// <param name="flag">The flags to check.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> does not have the bits
-            ///     specified in <paramref name="flag" /> set.
+            ///     <see cref="Argument" /> does not have the bits specified in
+            ///     <paramref name="flag" /> set.
             /// </exception>
+            [AssertionMethod]
             public EnumArgumentInfo<T> HasFlag(T flag, Func<T, T, string> message = null)
             {
                 if (!EnumInfo<T>.HasFlag(this.Argument.Value, flag))
@@ -235,20 +211,17 @@
                 return this;
             }
 
-            /// <summary>
-            ///     Requires the enum argument to have
-            ///     the specified flag bits unset.
-            /// </summary>
+            /// <summary>Requires the enum argument to have the specified flag bits unset.</summary>
             /// <param name="flag">The flags to check.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> have the bits specified
-            ///     in <paramref name="flag" /> set.
+            ///     <see cref="Argument" /> have the bits specified in <paramref name="flag" /> set.
             /// </exception>
+            [AssertionMethod]
             public EnumArgumentInfo<T> DoesNotHaveFlag(T flag, Func<T, T, string> message = null)
             {
                 if (EnumInfo<T>.HasFlag(this.Argument.Value, flag))
@@ -259,8 +232,6 @@
 
                 return this;
             }
-
-            #endregion Methods
         }
 
         /// <summary>Represents a method argument with a nullable enumeration value.</summary>
@@ -269,8 +240,6 @@
         public readonly struct NullableEnumArgumentInfo<T>
             where T : struct, IComparable, IFormattable
         {
-            #region Constructors
-
             /// <summary>
             ///     Initializes a new instance of the <see cref="NullableEnumArgumentInfo{T}" /> struct.
             /// </summary>
@@ -278,16 +247,8 @@
             internal NullableEnumArgumentInfo(ArgumentInfo<T?> argument)
                 => this.Argument = argument;
 
-            #endregion Constructors
-
-            #region Properties
-
             /// <summary>Gets the original argument.</summary>
             public ArgumentInfo<T?> Argument { get; }
-
-            #endregion Properties
-
-            #region Operators
 
             /// <summary>Gets the value of a nullable enum argument.</summary>
             /// <param name="argument">The argument whose value to return.</param>
@@ -295,14 +256,10 @@
             public static implicit operator T? (NullableEnumArgumentInfo<T> argument)
                 => argument.Argument.Value;
 
-            #endregion Operators
-
-            #region Methods
-
             /// <summary>Requires the nullable enum argument to be <c>null</c>.</summary>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns><see cref="Argument" />.</returns>
             /// <exception cref="ArgumentException">
@@ -319,41 +276,39 @@
                 return this.Argument;
             }
 
-            /// <summary>
-            ///     Requires the nullable enum argument to be not <c>null</c>.
-            /// </summary>
+            /// <summary>Requires the nullable enum argument to be not <c>null</c>.</summary>
             /// <param name="message">
-            ///     The message of the exception that will be thrown
-            ///     if the precondition is not satisfied.
+            ///     The message of the exception that will be thrown if the precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentNullException">
-            ///     <see cref="Argument" /> value is <c>null</c> and the
-            ///     argument is not modified since it is initialized.
+            ///     <see cref="Argument" /> value is <c>null</c> and the argument is not modified
+            ///     since it is initialized.
             /// </exception>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> value is <c>null</c> and
-            ///     the argument is modified after its initialization.
+            ///     <see cref="Argument" /> value is <c>null</c> and the argument is modified after
+            ///     its initialization.
             /// </exception>
             public EnumArgumentInfo<T> NotNull(string message = null)
 #pragma warning disable CS0618 // Type or member is obsolete
                 => this.Argument.NotNull(message).Enum();
+
 #pragma warning restore CS0618 // Type or member is obsolete
 
             /// <summary>
-            ///     Requires the nullable enum argument to be
-            ///     either a defined member of the enum type
-            ///     <typeparamref name="T" /> or <c>null</c>.
+            ///     Requires the nullable enum argument to be either a defined member of the enum
+            ///     type <typeparamref name="T" /> or <c>null</c>.
             /// </summary>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> value is not <c>null</c> and is not
-            ///     a defined member of the enum type <typeparamref name="T" />.
+            ///     <see cref="Argument" /> value is not <c>null</c> and is not a defined member of
+            ///     the enum type <typeparamref name="T" />.
             /// </exception>
             /// <returns>The current instance.</returns>
+            [AssertionMethod]
             public NullableEnumArgumentInfo<T> Defined(Func<T, string> message = null)
             {
                 if (this.NotNull(out var a))
@@ -363,18 +318,17 @@
             }
 
             /// <summary>
-            ///     Requires the nullable enum argument to either
-            ///     have none of its bits set or be <c>null</c>.
+            ///     Requires the nullable enum argument to either have none of its bits set or be <c>null</c>.
             /// </summary>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> value is not <c>null</c>
-            ///     and has one or more of its bits set.
+            ///     <see cref="Argument" /> value is not <c>null</c> and has one or more of its bits set.
             /// </exception>
+            [AssertionMethod]
             public NullableEnumArgumentInfo<T> None(Func<T, string> message = null)
             {
                 if (this.NotNull(out var a))
@@ -383,18 +337,16 @@
                 return this;
             }
 
-            /// <summary>
-            ///     Requires the enum argument to have at least one of its bits set.
-            /// </summary>
+            /// <summary>Requires the enum argument to have at least one of its bits set.</summary>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> value is not <c>null</c>
-            ///     and has none of its bits set.
+            ///     <see cref="Argument" /> value is not <c>null</c> and has none of its bits set.
             /// </exception>
+            [AssertionMethod]
             public NullableEnumArgumentInfo<T> NotNone(Func<T, string> message = null)
             {
                 if (this.NotNull(out var a))
@@ -404,19 +356,18 @@
             }
 
             /// <summary>
-            ///     Requires the nullable enum argument to either
-            ///     have the specified value or be <c>null</c>.
+            ///     Requires the nullable enum argument to either have the specified value or be <c>null</c>.
             /// </summary>
             /// <param name="other">The value to compare the argument value to.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> value is not <c>null</c>
-            ///     and is different than <paramref name="other" />.
+            ///     <see cref="Argument" /> value is not <c>null</c> and is different than <paramref name="other" />.
             /// </exception>
+            [AssertionMethod]
             public NullableEnumArgumentInfo<T> Equal(T other, Func<T, T, string> message = null)
             {
                 if (this.NotNull(out var a))
@@ -426,19 +377,19 @@
             }
 
             /// <summary>
-            ///     Requires the nullable enum argument to have a value that
-            ///     is either different than the specified value or <c>null</c>.
+            ///     Requires the nullable enum argument to have a value that is either different than
+            ///     the specified value or <c>null</c>.
             /// </summary>
             /// <param name="other">The value to compare the argument value to.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> value is not <c>null</c>
-            ///     and is equal to <paramref name="other" />.
+            ///     <see cref="Argument" /> value is not <c>null</c> and is equal to <paramref name="other" />.
             /// </exception>
+            [AssertionMethod]
             public NullableEnumArgumentInfo<T> NotEqual(T other, Func<T, string> message = null)
             {
                 if (this.NotNull(out var a))
@@ -448,19 +399,20 @@
             }
 
             /// <summary>
-            ///     Requires the nullable enum argument to either have
-            ///     the specified flag bits set or be <c>null</c>.
+            ///     Requires the nullable enum argument to either have the specified flag bits set or
+            ///     be <c>null</c>.
             /// </summary>
             /// <param name="flag">The flags to check.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> is not <c>null</c> and does not
-            ///     have the bits specified in <paramref name="flag" /> set.
+            ///     <see cref="Argument" /> is not <c>null</c> and does not have the bits specified
+            ///     in <paramref name="flag" /> set.
             /// </exception>
+            [AssertionMethod]
             public NullableEnumArgumentInfo<T> HasFlag(T flag, Func<T, T, string> message = null)
             {
                 if (this.NotNull(out var a))
@@ -470,19 +422,20 @@
             }
 
             /// <summary>
-            ///     Requires the nullable enum argument to either have
-            ///     the specified flag bits unset or be <c>null</c>.
+            ///     Requires the nullable enum argument to either have the specified flag bits unset
+            ///     or be <c>null</c>.
             /// </summary>
             /// <param name="flag">The flags to check.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that
-            ///     will be thrown if the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current instance.</returns>
             /// <exception cref="ArgumentException">
-            ///     <see cref="Argument" /> is not <c>null</c> and have
-            ///     the bits specified in <paramref name="flag" /> set.
+            ///     <see cref="Argument" /> is not <c>null</c> and have the bits specified in
+            ///     <paramref name="flag" /> set.
             /// </exception>
+            [AssertionMethod]
             public NullableEnumArgumentInfo<T> DoesNotHaveFlag(T flag, Func<T, T, string> message = null)
             {
                 if (this.NotNull(out var a))
@@ -492,17 +445,15 @@
             }
 
             /// <summary>
-            ///     Initializes an <see cref="EnumArgumentInfo{T}" />
-            ///     if the <see cref="Argument" /> is not <c>null</c>.
-            ///     A return value indicates whether the new argument is created.
+            ///     Initializes an <see cref="EnumArgumentInfo{T}" /> if the <see cref="Argument" />
+            ///     is not <c>null</c>. A return value indicates whether the new argument is created.
             /// </summary>
             /// <param name="result">
-            ///     The new enum argument, if the <see cref="Argument" /> is
-            ///     not <c>null</c>; otherwise, the uninitialized argument.
+            ///     The new enum argument, if the <see cref="Argument" /> is not <c>null</c>;
+            ///     otherwise, the uninitialized argument.
             /// </param>
             /// <returns>
-            ///     <c>true</c>, if the <see cref="Argument" />
-            ///     is not <c>null</c>; otherwise, <c>false</c>.
+            ///     <c>true</c>, if the <see cref="Argument" /> is not <c>null</c>; otherwise, <c>false</c>.
             /// </returns>
             private bool NotNull(out EnumArgumentInfo<T> result)
             {
@@ -521,10 +472,6 @@
                 result = default;
                 return false;
             }
-
-            #endregion Methods
         }
-
-        #endregion Structs
     }
 }

--- a/src/Guard.Enums.cs
+++ b/src/Guard.Enums.cs
@@ -3,13 +3,13 @@
     using System;
     using System.Collections.Generic;
     using System.Linq.Expressions;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="System.Enum" /> arguments.</content>
     public static partial class Guard
     {
         /// <summary>
-        ///     Requires the enum argument to have a value that is a defined member of the enum type
-        ///     <typeparamref name="T" />.
+        ///     Requires the enum argument to have a value that is a defined member of the enum type <typeparamref name="T" />.
         /// </summary>
         /// <param name="argument">The enum argument.</param>
         /// <param name="message">
@@ -18,9 +18,9 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not a defined member of the enum type
-        ///     <typeparamref name="T" />.
+        ///     <paramref name="argument" /> value is not a defined member of the enum type <typeparamref name="T" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Defined<T>(
             this in ArgumentInfo<T> argument, Func<T, string> message = null)
             where T : struct, System.Enum
@@ -45,9 +45,10 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is neither <c>null</c> nor a defined member of
-        ///     the enum type <typeparamref name="T" />.
+        ///     <paramref name="argument" /> value is neither <c>null</c> nor a defined member of the
+        ///     enum type <typeparamref name="T" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Defined<T>(
             this in ArgumentInfo<T?> argument, Func<T?, string> message = null)
             where T : struct, System.Enum
@@ -79,6 +80,7 @@
         ///     <paramref name="argument" /> value does not have the bits specified in
         ///     <paramref name="flag" /> set.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> HasFlag<T>(
             this in ArgumentInfo<T> argument, T flag, Func<T, T, string> message = null)
             where T : struct, System.Enum
@@ -107,6 +109,7 @@
         ///     <paramref name="argument" /> value is not <c>null</c> and does not have the bits
         ///     specified in <paramref name="flag" /> set.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> HasFlag<T>(
             this in ArgumentInfo<T?> argument, T flag, Func<T, T, string> message = null)
             where T : struct, System.Enum
@@ -138,6 +141,7 @@
         ///     <paramref name="argument" /> value has one or more of the bits specified in
         ///     <paramref name="flag" /> set.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> DoesNotHaveFlag<T>(
             this in ArgumentInfo<T> argument, T flag, Func<T, T, string> message = null)
             where T : struct, System.Enum
@@ -163,9 +167,10 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <c>null</c> and has one or more of the
-        ///     bits specified in <paramref name="flag" /> set.
+        ///     <paramref name="argument" /> value is not <c>null</c> and has one or more of the bits
+        ///     specified in <paramref name="flag" /> set.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> DoesNotHaveFlag<T>(
             this in ArgumentInfo<T?> argument, T flag, Func<T, T, string> message = null)
             where T : struct, System.Enum
@@ -184,8 +189,7 @@
         }
 
         /// <summary>
-        ///     Provides a compiled flag comparer and cached values of the enum type
-        ///     <typeparamref name="T" />.
+        ///     Provides a compiled flag comparer and cached values of the enum type <typeparamref name="T" />.
         /// </summary>
         /// <typeparam name="T">The type of the enum.</typeparam>
         private static class EnumInfo<T>
@@ -200,8 +204,7 @@
 
             /// <summary>Initializes <see cref="HasFlag" />.</summary>
             /// <returns>
-            ///     A function that checks whether an enum
-            ///     value has the specified flag bits set.
+            ///     A function that checks whether an enum value has the specified flag bits set.
             /// </returns>
             private static Func<T, T, bool> InitHasFlag()
             {

--- a/src/Guard.Generic.cs
+++ b/src/Guard.Generic.cs
@@ -2,24 +2,26 @@
 {
     using System;
     using System.Linq.Expressions;
+    using JetBrains.Annotations;
 
     /// <content>Provides generic preconditions.</content>
     public static partial class Guard
     {
-        /// <content>Contains the preconditions with generic type arguments that cannot be inferred.</content>
+        /// <content>
+        ///     Contains the preconditions with generic type arguments that cannot be inferred.
+        /// </content>
         public readonly partial struct ArgumentInfo<T>
         {
-
             /// <summary>Requires the argument to satisfy a condition.</summary>
             /// <param name="condition">Whether the precondition is satisfied.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that will be thrown if
-            ///     the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current argument.</returns>
-            /// <exception cref="ArgumentException">
-            ///     <paramref name="condition" /> is <c>false</c>.
-            /// </exception>
+            /// <exception cref="ArgumentException"><paramref name="condition" /> is <c>false</c>.</exception>
+            [AssertionMethod]
+            [ContractAnnotation("condition:false => halt")]
             public ArgumentInfo<T> Require(bool condition, Func<T, string> message = null)
                 => this.Require<ArgumentException>(condition, message);
 
@@ -28,19 +30,20 @@
             ///     exception if the condition is not met.
             /// </summary>
             /// <typeparam name="TException">
-            ///     The type of the exception to throw if the argument does not satisfy the
-            ///     specified condition.
+            ///     The type of the exception to throw if the argument does not satisfy the specified condition.
             /// </typeparam>
             /// <param name="condition">Whether the precondition is satisfied.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that will be thrown if
-            ///     the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current argument.</returns>
             /// <exception cref="Exception">
             ///     <paramref name="condition" /> is <c>false</c>. The exception thrown is an
             ///     instance of type <typeparamref name="TException" />.
             /// </exception>
+            [AssertionMethod]
+            [ContractAnnotation("condition:false => halt")]
             public ArgumentInfo<T> Require<TException>(
                 bool condition, Func<T, string> message = null)
                 where TException : Exception
@@ -57,14 +60,14 @@
             /// <summary>Requires the argument to satisfy a condition.</summary>
             /// <param name="predicate">The function to test the argument value.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that will be thrown if
-            ///     the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current argument.</returns>
             /// <exception cref="ArgumentException">
-            ///     <paramref name="predicate" /> returned <c>false</c> when supplied the
-            ///     <see cref="Value" />.
+            ///     <paramref name="predicate" /> returned <c>false</c> when supplied the <see cref="Value" />.
             /// </exception>
+            [AssertionMethod]
             public ArgumentInfo<T> Require(Func<T, bool> predicate, Func<T, string> message = null)
                 => this.Require<ArgumentException>(predicate, message);
 
@@ -73,20 +76,19 @@
             ///     exception if the condition is not met.
             /// </summary>
             /// <typeparam name="TException">
-            ///     The type of the exception to throw if the argument does not satisfy the
-            ///     specified condition.
+            ///     The type of the exception to throw if the argument does not satisfy the specified condition.
             /// </typeparam>
             /// <param name="predicate">The function to test the argument value.</param>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that will be thrown if
-            ///     the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current argument.</returns>
             /// <exception cref="Exception">
             ///     <paramref name="predicate" /> returned <c>false</c> when supplied the
-            ///     <see cref="Value" />. The exception thrown is an instance of type
-            ///     <typeparamref name="TException" />.
+            ///     <see cref="Value" />. The exception thrown is an instance of type <typeparamref name="TException" />.
             /// </exception>
+            [AssertionMethod]
             public ArgumentInfo<T> Require<TException>(
                 Func<T, bool> predicate, Func<T, string> message = null)
                 where TException : Exception
@@ -108,13 +110,14 @@
             ///     The type that the argument's value should be assignable to.
             /// </typeparam>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that will be thrown if
-            ///     the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current argument.</returns>
             /// <exception cref="ArgumentException">
             ///     <see cref="Value" /> cannot be assigned to type <typeparamref name="TTarget" />.
             /// </exception>
+            [AssertionMethod]
             public ArgumentInfo<T> Compatible<TTarget>(Func<T, string> message = null)
             {
                 if (!this.HasValue() || this.Value is TTarget value)
@@ -132,13 +135,14 @@
             ///     The type that the argument's value should not be assignable to.
             /// </typeparam>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that will be thrown if
-            ///     the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>The current argument.</returns>
             /// <exception cref="ArgumentException">
             ///     <see cref="Value" /> can be assigned to type <typeparamref name="TTarget" />.
             /// </exception>
+            [AssertionMethod]
             public ArgumentInfo<T> NotCompatible<TTarget>(Func<TTarget, string> message = null)
             {
                 if (this.HasValue() && this.Value is TTarget value)
@@ -155,21 +159,20 @@
             ///         Requires the argument to have a value that can be assigned to an instance of
             ///         the specified type.
             ///     </para>
-            ///     <para>
-            ///         The return value will be a new argument of type <typeparamref name="TTarget" />.
-            ///     </para>
+            ///     <para>The return value will be a new argument of type <typeparamref name="TTarget" />.</para>
             /// </summary>
             /// <typeparam name="TTarget">
             ///     The type that the argument's value should be assignable to.
             /// </typeparam>
             /// <param name="message">
-            ///     The factory to initialize the message of the exception that will be thrown if
-            ///     the precondition is not satisfied.
+            ///     The factory to initialize the message of the exception that will be thrown if the
+            ///     precondition is not satisfied.
             /// </param>
             /// <returns>A new <see cref="ArgumentInfo{TTarget}" />.</returns>
             /// <exception cref="ArgumentException">
             ///     <see cref="Value" /> cannot be assigned to type <typeparamref name="TTarget" />.
             /// </exception>
+            [AssertionMethod]
             public ArgumentInfo<TTarget> Cast<TTarget>(Func<T, string> message = null)
             {
                 if (this.Value is TTarget value)

--- a/src/Guard.IComparable.cs
+++ b/src/Guard.IComparable.cs
@@ -2,34 +2,31 @@
 {
     using System;
     using System.Collections.Generic;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="IComparable" /> arguments.</content>
     public static partial class Guard
     {
         /// <summary>
-        ///     Requires the argument to have a value that is
-        ///     equal to or greater than a specified value.
+        ///     Requires the argument to have a value that is equal to or greater than a specified value.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
-        /// <param name="minValue">
-        ///     The minimum value that the argument is allowed to have.
-        /// </param>
+        /// <param name="minValue">The minimum value that the argument is allowed to have.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is less than
-        ///     <paramref name="minValue" /> and the argument is
-        ///     not modified since it is initialized.
+        ///     <paramref name="argument" /> value is less than <paramref name="minValue" /> and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is less than
-        ///     <paramref name="minValue" /> and the argument
-        ///     is modified after its initialization.
+        ///     <paramref name="argument" /> value is less than <paramref name="minValue" /> and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Min<T>(
             in this ArgumentInfo<T> argument, in T minValue, Func<T, T, string> message = null)
             where T : IComparable<T>
@@ -46,30 +43,26 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a value that is
-        ///     <c>null</c>, equal to the specified value, or greater
-        ///     than the specified value.
+        ///     Requires the nullable argument to have a value that is <c>null</c>, equal to the
+        ///     specified value, or greater than the specified value.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
-        /// <param name="minValue">
-        ///     The minimum value that the argument is allowed to have.
-        /// </param>
+        /// <param name="minValue">The minimum value that the argument is allowed to have.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is less than
-        ///     <paramref name="minValue" /> and the argument is
-        ///     not modified since it is initialized.
+        ///     <paramref name="argument" /> value is less than <paramref name="minValue" /> and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is less than
-        ///     <paramref name="minValue" /> and the argument
-        ///     is modified after its initialization.
+        ///     <paramref name="argument" /> value is less than <paramref name="minValue" /> and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Min<T>(
             in this ArgumentInfo<T?> argument, in T minValue, Func<T, T, string> message = null)
             where T : struct, IComparable<T>
@@ -90,29 +83,25 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a value that is
-        ///     equal to or lower than a specified value.
+        ///     Requires the argument to have a value that is equal to or lower than a specified value.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
-        /// <param name="maxValue">
-        ///     The maximum value that the argument is allowed to have.
-        /// </param>
+        /// <param name="maxValue">The maximum value that the argument is allowed to have.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is greater than
-        ///     <paramref name="maxValue" /> and the argument is
-        ///     not modified since it is initialized.
+        ///     <paramref name="argument" /> value is greater than <paramref name="maxValue" /> and
+        ///     the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is greater than
-        ///     <paramref name="maxValue" /> and the argument
-        ///     is modified after its initialization.
+        ///     <paramref name="argument" /> value is greater than <paramref name="maxValue" /> and
+        ///     the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Max<T>(
             in this ArgumentInfo<T> argument, in T maxValue, Func<T, T, string> message = null)
             where T : IComparable<T>
@@ -129,30 +118,26 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a value that is
-        ///     <c>null</c>, equal to the specified value, or lower
-        ///     than the specified value.
+        ///     Requires the nullable argument to have a value that is <c>null</c>, equal to the
+        ///     specified value, or lower than the specified value.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
-        /// <param name="maxValue">
-        ///     The maximum value that the argument is allowed to have.
-        /// </param>
+        /// <param name="maxValue">The maximum value that the argument is allowed to have.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is greater than
-        ///     <paramref name="maxValue" /> and the argument is
-        ///     not modified since it is initialized.
+        ///     <paramref name="argument" /> value is greater than <paramref name="maxValue" /> and
+        ///     the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is greater than
-        ///     <paramref name="maxValue" /> and the argument
-        ///     is modified after its initialization.
+        ///     <paramref name="argument" /> value is greater than <paramref name="maxValue" /> and
+        ///     the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Max<T>(
             in this ArgumentInfo<T?> argument, in T maxValue, Func<T, T, string> message = null)
             where T : struct, IComparable<T>
@@ -173,32 +158,27 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a value that is between
-        ///     the specified minimum and maximum values.
+        ///     Requires the argument to have a value that is between the specified minimum and
+        ///     maximum values.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
-        /// <param name="minValue">
-        ///     The minimum value that the argument is allowed to have.
-        /// </param>
-        /// <param name="maxValue">
-        ///     The maximum value that the argument is allowed to have.
-        /// </param>
+        /// <param name="minValue">The minimum value that the argument is allowed to have.</param>
+        /// <param name="maxValue">The maximum value that the argument is allowed to have.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not between
-        ///     <paramref name="minValue"/> and <paramref name="maxValue"/>.
-        ///     And the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not between <paramref name="minValue" /> and
+        ///     <paramref name="maxValue" />. And the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not between
-        ///     <paramref name="minValue"/> and <paramref name="maxValue"/>.
-        ///     And the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not between <paramref name="minValue" /> and
+        ///     <paramref name="maxValue" />. And the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> InRange<T>(
             in this ArgumentInfo<T> argument, in T minValue, in T maxValue, Func<T, T, T, string> message = null)
             where T : IComparable<T>
@@ -220,32 +200,29 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a value that is either
-        ///     between the specified minimum and maximum values or <c>null</c>.
+        ///     Requires the nullable argument to have a value that is either between the specified
+        ///     minimum and maximum values or <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
-        /// <param name="minValue">
-        ///     The minimum value that the argument is allowed to have.
-        /// </param>
-        /// <param name="maxValue">
-        ///     The maximum value that the argument is allowed to have.
-        /// </param>
+        /// <param name="minValue">The minimum value that the argument is allowed to have.</param>
+        /// <param name="maxValue">The maximum value that the argument is allowed to have.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not <c>null</c> and is not
-        ///     between <paramref name="minValue"/> and <paramref name="maxValue"/>.
-        ///     And the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not <c>null</c> and is not between
+        ///     <paramref name="minValue" /> and <paramref name="maxValue" />. And the argument is
+        ///     not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <c>null</c> and is not
-        ///     between <paramref name="minValue"/> and <paramref name="maxValue"/>.
-        ///     And the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not <c>null</c> and is not between
+        ///     <paramref name="minValue" /> and <paramref name="maxValue" />. And the argument is
+        ///     modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> InRange<T>(
             in this ArgumentInfo<T?> argument, in T minValue, in T maxValue, Func<T, T, T, string> message = null)
             where T : struct, IComparable<T>
@@ -274,18 +251,18 @@
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not zero and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not zero and the argument is not modified since
+        ///     it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not zero and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not zero and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Zero<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message = null)
             where T : struct, IComparable<T>
@@ -302,31 +279,29 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a
-        ///     value that is either zero or <c>null</c>.
+        ///     Requires the nullable argument to have a value that is either zero or <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not zero and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not zero and the argument is not modified since
+        ///     it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not zero and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not zero and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Zero<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message = null)
             where T : struct, IComparable<T>
@@ -350,18 +325,18 @@
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is zero and the
-        ///     argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is zero and the argument is not modified since it
+        ///     is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is zero and the
-        ///     argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is zero and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         [Obsolete("Use the NotZero overload that accepts the message as a string.")]
         public static ref readonly ArgumentInfo<T> NotZero<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message)
@@ -382,18 +357,17 @@
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The message of the exception that will be thrown
-        ///     if the precondition is not satisfied.
+        ///     The message of the exception that will be thrown if the precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is zero and the
-        ///     argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is zero and the argument is not modified since it
+        ///     is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is zero and the
-        ///     argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is zero and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> NotZero<T>(
             in this ArgumentInfo<T> argument, string message = null)
             where T : struct, IComparable<T>
@@ -410,31 +384,29 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a value
-        ///     that either is not zero or is <c>null</c>.
+        ///     Requires the nullable argument to have a value that either is not zero or is <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is zero and the
-        ///     argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is zero and the argument is not modified since it
+        ///     is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is zero and the
-        ///     argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is zero and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         [Obsolete("Use the NotZero overload that accepts the message as a string.")]
         public static ref readonly ArgumentInfo<T?> NotZero<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message)
@@ -452,31 +424,28 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a value
-        ///     that either is not zero or is <c>null</c>.
+        ///     Requires the nullable argument to have a value that either is not zero or is <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The message of the exception that will be thrown
-        ///     if the precondition is not satisfied.
+        ///     The message of the exception that will be thrown if the precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is zero and the
-        ///     argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is zero and the argument is not modified since it
+        ///     is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is zero and the
-        ///     argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is zero and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> NotZero<T>(
             in this ArgumentInfo<T?> argument, string message = null)
             where T : struct, IComparable<T>
@@ -496,24 +465,23 @@
             return ref argument;
         }
 
-        /// <summary>
-        ///     Requires the argument to have a value that is greater than zero.
-        /// </summary>
+        /// <summary>Requires the argument to have a value that is greater than zero.</summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is zero or less, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is zero or less, and the argument is not modified
+        ///     since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is zero or less, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is zero or less, and the argument is modified
+        ///     after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Positive<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message = null)
             where T : struct, IComparable<T>
@@ -530,31 +498,30 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a value that
-        ///     is either greater than zero or <c>null</c>.
+        ///     Requires the argument to have a value that is either greater than zero or <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is zero or less, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is zero or less, and the argument is not modified
+        ///     since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is zero or less, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is zero or less, and the argument is modified
+        ///     after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Positive<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message = null)
             where T : struct, IComparable<T>
@@ -574,24 +541,23 @@
             return ref argument;
         }
 
-        /// <summary>
-        ///     Requires the argument to have a value that is not greater than zero.
-        /// </summary>
+        /// <summary>Requires the argument to have a value that is not greater than zero.</summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is greater than zero,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is greater than zero, and the argument is not
+        ///     modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is greater than zero,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is greater than zero, and the argument is modified
+        ///     after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> NotPositive<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message = null)
             where T : struct, IComparable<T>
@@ -608,31 +574,30 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have
-        ///     a value that is not greater than zero.
+        ///     Requires the nullable argument to have a value that is not greater than zero.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is greater than zero,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is greater than zero, and the argument is not
+        ///     modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is greater than zero,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is greater than zero, and the argument is modified
+        ///     after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> NotPositive<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message = null)
             where T : struct, IComparable<T>
@@ -652,24 +617,23 @@
             return ref argument;
         }
 
-        /// <summary>
-        ///     Requires the argument to have a value that is less than zero.
-        /// </summary>
+        /// <summary>Requires the argument to have a value that is less than zero.</summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is zero or greater,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is zero or greater, and the argument is not
+        ///     modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is zero or greater,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is zero or greater, and the argument is modified
+        ///     after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Negative<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message = null)
             where T : struct, IComparable<T>
@@ -686,31 +650,30 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a value
-        ///     that is either less than zero or <c>null</c>.
+        ///     Requires the nullable argument to have a value that is either less than zero or <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is zero or greater,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is zero or greater, and the argument is not
+        ///     modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is zero or greater,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is zero or greater, and the argument is modified
+        ///     after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Negative<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message = null)
             where T : struct, IComparable<T>
@@ -730,24 +693,23 @@
             return ref argument;
         }
 
-        /// <summary>
-        ///     Requires the argument to have a value that is not less than zero.
-        /// </summary>
+        /// <summary>Requires the argument to have a value that is not less than zero.</summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is less than zero,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is less than zero, and the argument is not
+        ///     modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is less than zero,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is less than zero, and the argument is modified
+        ///     after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> NotNegative<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message = null)
             where T : struct, IComparable<T>
@@ -764,31 +726,30 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have
-        ///     a value that is not less than zero.
+        ///     Requires the nullable argument to have a value that is not less than zero.
         /// </summary>
         /// <typeparam name="T">The type of the comparable argument.</typeparam>
         /// <param name="argument">The comparable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is less than zero,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is less than zero, and the argument is not
+        ///     modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is less than zero,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is less than zero, and the argument is modified
+        ///     after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> NotNegative<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message = null)
             where T : struct, IComparable<T>

--- a/src/Guard.IEnumerable.cs
+++ b/src/Guard.IEnumerable.cs
@@ -484,7 +484,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="items" /> contains the <paramref name="argument" /> value.
         /// </exception>
-        internal static ref readonly ArgumentInfo<TItem> NotIn<TItem>(
+        public static ref readonly ArgumentInfo<TItem> NotIn<TItem>(
             in this ArgumentInfo<TItem> argument, params TItem[] items)
         {
             if (argument.HasValue() && items != null)

--- a/src/Guard.IEnumerable.cs
+++ b/src/Guard.IEnumerable.cs
@@ -8,6 +8,7 @@
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using System.Threading;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="IEnumerable" /> arguments.</content>
     public static partial class Guard
@@ -16,13 +17,14 @@
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         /// <param name="argument">The collection argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> has one or more items.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> Empty<TCollection>(
             in this ArgumentInfo<TCollection> argument, Func<TCollection, string> message = null)
             where TCollection : IEnumerable
@@ -36,19 +38,18 @@
             return ref argument;
         }
 
-        /// <summary>
-        ///     Requires the argument to have a collection value that is not empty.
-        /// </summary>
+        /// <summary>Requires the argument to have a collection value that is not empty.</summary>
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         /// <param name="argument">The collection argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> is not <c>null</c> and has no items.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> NotEmpty<TCollection>(
             in this ArgumentInfo<TCollection> argument, Func<TCollection, string> message = null)
             where TCollection : IEnumerable
@@ -63,8 +64,8 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a collection value that contains at least the
-        ///     specified number of items.
+        ///     Requires the argument to have a collection value that contains at least the specified
+        ///     number of items.
         /// </summary>
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         /// <param name="argument">The collection argument.</param>
@@ -79,6 +80,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> contains less than the specified number of items.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> MinCount<TCollection>(
             in this ArgumentInfo<TCollection> argument, int minCount, Func<TCollection, int, string> message = null)
             where TCollection : IEnumerable
@@ -109,6 +111,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> contains more than the specified number of items.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> MaxCount<TCollection>(
             in this ArgumentInfo<TCollection> argument, int maxCount, Func<TCollection, int, string> message = null)
             where TCollection : IEnumerable
@@ -123,8 +126,8 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a collection value whose number of items is between
-        ///     the specified minimum and maximum values.
+        ///     Requires the argument to have a collection value whose number of items is between the
+        ///     specified minimum and maximum values.
         /// </summary>
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         /// <param name="argument">The collection argument.</param>
@@ -143,6 +146,7 @@
         ///     The number of items that the <paramref name="argument" /> value contains is either
         ///     less than <paramref name="minCount" /> or greater than <paramref name="maxCount" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> CountInRange<TCollection>(
             in this ArgumentInfo<TCollection> argument, int minCount, int maxCount, Func<TCollection, int, int, string> message = null)
             where TCollection : IEnumerable
@@ -177,6 +181,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> does not contain <paramref name="item" />.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<TCollection> Contains<TCollection, TItem>(
             in this ArgumentInfo<TCollection> argument, in TItem item, Func<TCollection, TItem, string> message = null)
@@ -200,6 +205,7 @@
         ///     <paramref name="argument" /> does not contain <paramref name="item" /> by the
         ///     comparison made by <paramref name="comparer" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> Contains<TCollection, TItem>(
             in this ArgumentInfo<TCollection> argument,
             in TItem item,
@@ -217,8 +223,7 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a collection value that does not contain the
-        ///     specified item.
+        ///     Requires the argument to have a collection value that does not contain the specified item.
         /// </summary>
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         /// <typeparam name="TItem">The type of the collection items.</typeparam>
@@ -229,9 +234,8 @@
         ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> contains <paramref name="item" />.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> contains <paramref name="item" />.</exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<TCollection> DoesNotContain<TCollection, TItem>(
             in this ArgumentInfo<TCollection> argument, in TItem item, Func<TCollection, TItem, string> message = null)
@@ -239,8 +243,7 @@
             => ref argument.DoesNotContain(item, null, message);
 
         /// <summary>
-        ///     Requires the argument to have a collection value that does not contain the
-        ///     specified item.
+        ///     Requires the argument to have a collection value that does not contain the specified item.
         /// </summary>
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         /// <typeparam name="TItem">The type of the collection items.</typeparam>
@@ -253,9 +256,10 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> contains <paramref name="item" /> by the comparison
-        ///     made by <paramref name="comparer" />.
+        ///     <paramref name="argument" /> contains <paramref name="item" /> by the comparison made
+        ///     by <paramref name="comparer" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> DoesNotContain<TCollection, TItem>(
             in this ArgumentInfo<TCollection> argument,
             in TItem item,
@@ -285,6 +289,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> does not contain <c>null</c>.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> ContainsNull<TCollection>(
             in this ArgumentInfo<TCollection> argument, Func<TCollection, string> message = null)
             where TCollection : IEnumerable
@@ -299,8 +304,7 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a collection value that does not contain a
-        ///     <c>null</c> element.
+        ///     Requires the argument to have a collection value that does not contain a <c>null</c> element.
         /// </summary>
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         /// <param name="argument">The collection argument.</param>
@@ -309,9 +313,8 @@
         ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> contains <c>null</c>.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> contains <c>null</c>.</exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TCollection> DoesNotContainNull<TCollection>(
             in this ArgumentInfo<TCollection> argument, Func<TCollection, string> message = null)
             where TCollection : IEnumerable
@@ -338,9 +341,9 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="collection" /> does not contain the <paramref name="argument" />
-        ///     value.
+        ///     <paramref name="collection" /> does not contain the <paramref name="argument" /> value.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<TItem> In<TCollection, TItem>(
             in this ArgumentInfo<TItem> argument,
@@ -366,6 +369,7 @@
         ///     <paramref name="collection" /> does not contain the <paramref name="argument" />
         ///     value by the comparison made by <paramref name="comparer" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TItem> In<TCollection, TItem>(
             in this ArgumentInfo<TItem> argument,
             TCollection collection,
@@ -389,14 +393,12 @@
         /// <summary>Requires the specified items to contain the argument value.</summary>
         /// <typeparam name="TItem">The type of the argument.</typeparam>
         /// <param name="argument">The argument.</param>
-        /// <param name="items">
-        ///     The items that is required to contain the argument value.
-        /// </param>
+        /// <param name="items">The items that is required to contain the argument value.</param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="items" /> does not contain the <paramref name="argument" />
-        ///     value.
+        ///     <paramref name="items" /> does not contain the <paramref name="argument" /> value.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TItem> In<TItem>(
             in this ArgumentInfo<TItem> argument, params TItem[] items)
         {
@@ -429,6 +431,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="collection" /> contains the <paramref name="argument" /> value.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<TItem> NotIn<TCollection, TItem>(
             in this ArgumentInfo<TItem> argument,
@@ -451,9 +454,10 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="collection" /> contains the <paramref name="argument" /> value by
-        ///     the comparison made by <paramref name="comparer" />.
+        ///     <paramref name="collection" /> contains the <paramref name="argument" /> value by the
+        ///     comparison made by <paramref name="comparer" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TItem> NotIn<TCollection, TItem>(
             in this ArgumentInfo<TItem> argument,
             TCollection collection,
@@ -477,13 +481,12 @@
         /// <summary>Requires the specified items not to contain the argument value.</summary>
         /// <typeparam name="TItem">The type of the argument.</typeparam>
         /// <param name="argument">The argument.</param>
-        /// <param name="items">
-        ///     The items that is required not to contain the argument value.
-        /// </param>
+        /// <param name="items">The items that is required not to contain the argument value.</param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
         ///     <paramref name="items" /> contains the <paramref name="argument" /> value.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<TItem> NotIn<TItem>(
             in this ArgumentInfo<TItem> argument, params TItem[] items)
         {
@@ -511,47 +514,38 @@
             public static readonly IDictionary<Type, Func<object, int, int>> CachedCountFunctions
                 = new Dictionary<Type, Func<object, int, int>>();
 
-            /// <summary>
-            ///     The locker that synchronizes access to <see cref="CachedCountFunctions" />.
-            /// </summary>
+            /// <summary>The locker that synchronizes access to <see cref="CachedCountFunctions" />.</summary>
             public static readonly ReaderWriterLockSlim CachedCountFunctionsLocker = new ReaderWriterLockSlim();
 
             /// <summary>
-            ///     The <see cref="Collection{TCollection}.ContainsNull" /> delegates cached by
-            ///     their collection types.
+            ///     The <see cref="Collection{TCollection}.ContainsNull" /> delegates cached by their
+            ///     collection types.
             /// </summary>
             public static readonly IDictionary<Type, Func<object, bool>> CachedContainsNullFunctions
                 = new Dictionary<Type, Func<object, bool>>();
 
-            /// <summary>
-            ///     The locker that synchronizes access to <see cref="CachedContainsNullFunctions" />.
-            /// </summary>
+            /// <summary>The locker that synchronizes access to <see cref="CachedContainsNullFunctions" />.</summary>
             public static readonly ReaderWriterLockSlim CachedContainsNullFunctionsLocker = new ReaderWriterLockSlim();
 
             /// <summary>
-            ///     The <see cref="Collection{TCollection}.Typed{TItem}.Contains" /> delegates
-            ///     cached by their collection and item types.
+            ///     The <see cref="Collection{TCollection}.Typed{TItem}.Contains" /> delegates cached
+            ///     by their collection and item types.
             /// </summary>
             public static readonly IDictionary<(Type, Type), Delegate> CachedContainsFunctions
                 = new Dictionary<(Type, Type), Delegate>();
 
-            /// <summary>
-            ///     The locker that synchronizes access to <see cref="CachedContainsFunctions" />.
-            /// </summary>
+            /// <summary>The locker that synchronizes access to <see cref="CachedContainsFunctions" />.</summary>
             public static readonly ReaderWriterLockSlim CachedContainsFunctionsLocker = new ReaderWriterLockSlim();
         }
 
-        /// <summary>
-        ///     Provides cached collection utilities for the type
-        ///     <typeparamref name="TCollection" />.
-        /// </summary>
+        /// <summary>Provides cached collection utilities for the type <typeparamref name="TCollection" />.</summary>
         /// <typeparam name="TCollection">The type of the collection.</typeparam>
         private static class Collection<TCollection>
             where TCollection : IEnumerable
         {
             /// <summary>
-            ///     A function that returns the number of elements in the specified collection.
-            ///     It enumerates the collection and counts the elements if the collection does not
+            ///     A function that returns the number of elements in the specified collection. It
+            ///     enumerates the collection and counts the elements if the collection does not
             ///     provide a Count/Length property. The integer parameter specifies the maximum
             ///     number of iterations.
             /// </summary>
@@ -605,9 +599,8 @@
                     var enumerator = collection.GetEnumerator();
                     try
                     {
-                        for (; i < max && enumerator.MoveNext(); i++)
-                        {
-                        }
+                        while (i < max && enumerator.MoveNext())
+                            i++;
                     }
                     finally
                     {
@@ -756,7 +749,7 @@
                             }
                         }
 
-                        func = del as Func<object, bool>;
+                        func = del;
                     }
                     finally
                     {
@@ -768,8 +761,7 @@
             }
 
             /// <summary>
-            ///     Provides cached collection utilities for collections that contain instances of
-            ///     <typeparamref name="TItem" />.
+            ///     Provides cached collection utilities for collections that contain instances of <typeparamref name="TItem" />.
             /// </summary>
             /// <typeparam name="TItem">The type of the collection items.</typeparam>
             public static class Typed<TItem>

--- a/src/Guard.IEquatable.cs
+++ b/src/Guard.IEquatable.cs
@@ -3,25 +3,23 @@
     using System;
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="IEquatable{T}" /> arguments.</content>
     public static partial class Guard
     {
-        /// <summary>
-        ///     Requires the argument to have the default
-        ///     value of type <typeparamref name="T" />.
-        /// </summary>
+        /// <summary>Requires the argument to have the default value of type <typeparamref name="T" />.</summary>
         /// <typeparam name="T">The type of the equatable argument.</typeparam>
         /// <param name="argument">The equatable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> does not have the
-        ///     default value of type <typeparamref name="T" />.
+        ///     <paramref name="argument" /> does not have the default value of type <typeparamref name="T" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Default<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message = null)
             where T : struct
@@ -36,20 +34,21 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a value that is either the
-        ///     default value of type <typeparamref name="T" /> or <c>null</c>.
+        ///     Requires the nullable argument to have a value that is either the default value of
+        ///     type <typeparamref name="T" /> or <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of the equatable argument.</typeparam>
         /// <param name="argument">The equatable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is neither the default value
-        ///     of type <typeparamref name="T" /> nor <c>null</c>.
+        ///     <paramref name="argument" /> value is neither the default value of type
+        ///     <typeparamref name="T" /> nor <c>null</c>.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Default<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message = null)
             where T : struct
@@ -68,20 +67,19 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a value that is not
-        ///     the default value of type <typeparamref name="T" />.
+        ///     Requires the argument to have a value that is not the default value of type <typeparamref name="T" />.
         /// </summary>
         /// <typeparam name="T">The type of the equatable argument.</typeparam>
         /// <param name="argument">The equatable argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> have the default
-        ///     value of type <typeparamref name="T" />.
+        ///     <paramref name="argument" /> have the default value of type <typeparamref name="T" />.
         /// </exception>
+        [AssertionMethod]
         [Obsolete("Use the NotDefault overload that accepts the message as a string.")]
         public static ref readonly ArgumentInfo<T> NotDefault<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message)
@@ -97,20 +95,18 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a value that is not
-        ///     the default value of type <typeparamref name="T" />.
+        ///     Requires the argument to have a value that is not the default value of type <typeparamref name="T" />.
         /// </summary>
         /// <typeparam name="T">The type of the equatable argument.</typeparam>
         /// <param name="argument">The equatable argument.</param>
         /// <param name="message">
-        ///     The message of the exception that will be thrown
-        ///     if the precondition is not satisfied.
+        ///     The message of the exception that will be thrown if the precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> have the default
-        ///     value of type <typeparamref name="T" />.
+        ///     <paramref name="argument" /> have the default value of type <typeparamref name="T" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> NotDefault<T>(
             in this ArgumentInfo<T> argument, string message = null)
             where T : struct
@@ -125,20 +121,18 @@
         }
 
         /// <summary>
-        ///     Requires the nullable argument to have a value that is not
-        ///     the default value of type <typeparamref name="T" />.
+        ///     Requires the nullable argument to have a value that is not the default value of type <typeparamref name="T" />.
         /// </summary>
         /// <typeparam name="T">The type of the equatable argument.</typeparam>
         /// <param name="argument">The equatable argument.</param>
         /// <param name="message">
-        ///     The message of the exception that will be thrown
-        ///     if the precondition is not satisfied.
+        ///     The message of the exception that will be thrown if the precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> have the default
-        ///     value of type <typeparamref name="T" />.
+        ///     <paramref name="argument" /> have the default value of type <typeparamref name="T" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> NotDefault<T>(
             in this ArgumentInfo<T?> argument, string message = null)
             where T : struct
@@ -161,14 +155,14 @@
         /// <param name="argument">The equatable argument.</param>
         /// <param name="other">The value to compare the argument value to.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is
-        ///     different than <paramref name="other" />.
+        ///     <paramref name="argument" /> value is different than <paramref name="other" />.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<T> Equal<T>(
             in this ArgumentInfo<T> argument, in T other, Func<T, T, string> message = null)
@@ -180,15 +174,15 @@
         /// <param name="other">The value to compare the argument value to.</param>
         /// <param name="comparer">The equality comparer to use.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is different than
-        ///     <paramref name="other" /> by the comparison made by
-        ///     <paramref name="comparer" />.
+        ///     <paramref name="argument" /> value is different than <paramref name="other" /> by the
+        ///     comparison made by <paramref name="comparer" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Equal<T>(
             in this ArgumentInfo<T> argument,
             in T other,
@@ -205,44 +199,42 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a value that
-        ///     is different than the specified value.
+        ///     Requires the argument to have a value that is different than the specified value.
         /// </summary>
         /// <typeparam name="T">The type of the equatable argument.</typeparam>
         /// <param name="argument">The equatable argument.</param>
         /// <param name="other">The value to compare the argument value to.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref = "ArgumentException" >
-        ///     <paramref name="argument" /> value is
-        ///     equal to <paramref name="other" />.
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="argument" /> value is equal to <paramref name="other" />.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<T> NotEqual<T>(
             in this ArgumentInfo<T> argument, in T other, Func<T, string> message = null)
             => ref argument.NotEqual(other, null, message);
 
         /// <summary>
-        ///     Requires the argument to have a value that
-        ///     is different than the specified value.
+        ///     Requires the argument to have a value that is different than the specified value.
         /// </summary>
         /// <typeparam name="T">The type of the equatable argument.</typeparam>
         /// <param name="argument">The equatable argument.</param>
         /// <param name="other">The value to compare the argument value to.</param>
         /// <param name="comparer">The equality comparer to use.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref = "ArgumentException" >
-        ///     <paramref name="argument" /> value is equal to
-        ///     <paramref name="other" /> by the comparison made by
-        ///     <paramref name="comparer" />.
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="argument" /> value is equal to <paramref name="other" /> by the
+        ///     comparison made by <paramref name="comparer" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> NotEqual<T>(
             in this ArgumentInfo<T> argument,
             in T other,

--- a/src/Guard.Member.cs
+++ b/src/Guard.Member.cs
@@ -6,6 +6,7 @@
     using System.Reflection;
     using System.Runtime.CompilerServices;
     using System.Threading;
+    using JetBrains.Annotations;
 
     /// <content>Provides routed member preconditions.</content>
     public static partial class Guard
@@ -14,9 +15,7 @@
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <typeparam name="TMember">The type of the argument member to validate.</typeparam>
         /// <param name="argument">The argument.</param>
-        /// <param name="member">
-        ///     An expression that specifies the argument member to validate.
-        /// </param>
+        /// <param name="member">An expression that specifies the argument member to validate.</param>
         /// <param name="validation">The function to test the argument member against.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
@@ -24,10 +23,11 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="member" /> is not composed of <see cref="MemberExpression" />s,
+        ///     <paramref name="member" /> is not composed of <see cref="MemberExpression" /> s,
         ///     member value cannot be retrieved using the compiled member expression, or
         ///     <paramref name="validation" /> has thrown an exception.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<T> Member<T, TMember>(
             in this ArgumentInfo<T> argument,
@@ -40,13 +40,11 @@
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <typeparam name="TMember">The type of the argument member to validate.</typeparam>
         /// <param name="argument">The argument.</param>
-        /// <param name="member">
-        ///     An expression that specifies the argument member to validate.
-        /// </param>
+        /// <param name="member">An expression that specifies the argument member to validate.</param>
         /// <param name="validation">The function to test the argument member against.</param>
         /// <param name="validatesRange">
-        ///     Pass <c>true</c> to throw an <see cref="ArgumentOutOfRangeException" /> instead of
-        ///     an <see cref="ArgumentException" /> if the precondition is not satisfied.
+        ///     Pass <c>true</c> to throw an <see cref="ArgumentOutOfRangeException" /> instead of an
+        ///     <see cref="ArgumentException" /> if the precondition is not satisfied.
         /// </param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
@@ -54,7 +52,7 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="member" /> is not composed of <see cref="MemberExpression" />s,
+        ///     <paramref name="member" /> is not composed of <see cref="MemberExpression" /> s,
         ///     member value cannot be retrieved using the compiled member expression, or
         ///     <paramref name="validation" /> has thrown an exception when
         ///     <paramref name="validatesRange" /> passed <c>false</c>.
@@ -63,6 +61,7 @@
         ///     <paramref name="validation" /> has thrown an exception when
         ///     <paramref name="validatesRange" /> passed <c>true</c>.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Member<T, TMember>(
             in this ArgumentInfo<T> argument,
             Expression<Func<T, TMember>> member,
@@ -117,9 +116,7 @@
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <typeparam name="TMember">The type of the argument member to validate.</typeparam>
         /// <param name="argument">The argument.</param>
-        /// <param name="member">
-        ///     An expression that specifies the argument member to validate.
-        /// </param>
+        /// <param name="member">An expression that specifies the argument member to validate.</param>
         /// <param name="validation">The function to test the argument member against.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
@@ -127,10 +124,11 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="member" /> is not composed of <see cref="MemberExpression" />s,
+        ///     <paramref name="member" /> is not composed of <see cref="MemberExpression" /> s,
         ///     member value cannot be retrieved using the compiled member expression, or
         ///     <paramref name="validation" /> has thrown an exception.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<T?> Member<T, TMember>(
             in this ArgumentInfo<T?> argument,
@@ -144,13 +142,11 @@
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <typeparam name="TMember">The type of the argument member to validate.</typeparam>
         /// <param name="argument">The argument.</param>
-        /// <param name="member">
-        ///     An expression that specifies the argument member to validate.
-        /// </param>
+        /// <param name="member">An expression that specifies the argument member to validate.</param>
         /// <param name="validation">The function to test the argument member against.</param>
         /// <param name="validatesRange">
-        ///     Pass <c>true</c> to throw an <see cref="ArgumentOutOfRangeException" /> instead of
-        ///     an <see cref="ArgumentException" /> if the precondition is not satisfied.
+        ///     Pass <c>true</c> to throw an <see cref="ArgumentOutOfRangeException" /> instead of an
+        ///     <see cref="ArgumentException" /> if the precondition is not satisfied.
         /// </param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
@@ -158,7 +154,7 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="member" /> is not composed of <see cref="MemberExpression" />s,
+        ///     <paramref name="member" /> is not composed of <see cref="MemberExpression" /> s,
         ///     member value cannot be retrieved using the compiled member expression, or
         ///     <paramref name="validation" /> has thrown an exception when
         ///     <paramref name="validatesRange" /> passed <c>false</c>.
@@ -167,6 +163,7 @@
         ///     <paramref name="validation" /> has thrown an exception when
         ///     <paramref name="validatesRange" /> passed <c>true</c>.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Member<T, TMember>(
             in this ArgumentInfo<T?> argument,
             Expression<Func<T, TMember>> member,
@@ -229,9 +226,7 @@
             private static readonly ReaderWriterLockSlim CacheLock
                 = new ReaderWriterLockSlim();
 
-            /// <summary>
-            ///     Returns the cached argument member for the specified lambda expression.
-            /// </summary>
+            /// <summary>Returns the cached argument member for the specified lambda expression.</summary>
             /// <typeparam name="T">The type of the argument.</typeparam>
             /// <typeparam name="TMember">The type of the argument member.</typeparam>
             /// <param name="lexp">
@@ -291,8 +286,7 @@
         private sealed class ArgumentMemberInfo<T, TMember> : ArgumentMemberInfo
         {
             /// <summary>
-            ///     Initializes a new instance of the <see cref="ArgumentMemberInfo{T, TMember}" />
-            ///     class.
+            ///     Initializes a new instance of the <see cref="ArgumentMemberInfo{T, TMember}" /> class.
             /// </summary>
             /// <param name="mexp">The member expression.</param>
             /// <param name="getValue">

--- a/src/Guard.Modify.cs
+++ b/src/Guard.Modify.cs
@@ -1,13 +1,12 @@
 ﻿namespace Dawn
 {
     using System;
+    using JetBrains.Annotations;
 
     /// <content>Provides safe modification functions to normalize arguments.</content>
     public static partial class Guard
     {
-        /// <summary>
-        ///     Returns a new argument with the same name and the specified value.
-        /// </summary>
+        /// <summary>Returns a new argument with the same name and the specified value.</summary>
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <param name="argument">The existing argument.</param>
         /// <param name="value">The new argument value.</param>
@@ -16,20 +15,19 @@
             => new ArgumentInfo<T>(value, argument.Name, true, argument.Secure);
 
         /// <summary>
-        ///     Returns a new argument with the same name and a value that
-        ///     is created using the specified conversion function.
+        ///     Returns a new argument with the same name and a value that is created using the
+        ///     specified conversion function.
         /// </summary>
         /// <typeparam name="TSource">The type of the existing argument.</typeparam>
         /// <typeparam name="TTarget">The type of the new argument.</typeparam>
         /// <param name="argument">The existing argument.</param>
         /// <param name="convert">
-        ///     A function that accepts the existing argument's value and
-        ///     returns a new object to be used as the new argument's value.
+        ///     A function that accepts the existing argument's value and returns a new object to be
+        ///     used as the new argument's value.
         /// </param>
         /// <returns>A new <see cref="ArgumentInfo{TTarget}" />.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="convert" /> is <c>null</c>.
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="convert" /> is <c>null</c>.</exception>
+        [ContractAnnotation("convert:null => halt")]
         public static ArgumentInfo<TTarget> Modify<TSource, TTarget>(
             in this ArgumentInfo<TSource> argument, Func<TSource, TTarget> convert)
         {
@@ -40,32 +38,28 @@
 
         /// <summary>
         ///     <para>
-        ///         Returns a new argument with the same name and a value that
-        ///         is created using the specified conversion function.
+        ///         Returns a new argument with the same name and a value that is created using the
+        ///         specified conversion function.
         ///     </para>
         ///     <para>
-        ///         If the conversion function throws an exception, it will
-        ///         be wrapped in an <see cref="ArgumentException" />.
+        ///         If the conversion function throws an exception, it will be wrapped in an <see cref="ArgumentException" />.
         ///     </para>
         /// </summary>
         /// <typeparam name="TSource">The type of the existing argument.</typeparam>
         /// <typeparam name="TTarget">The type of the new argument.</typeparam>
         /// <param name="argument">The existing argument.</param>
         /// <param name="convert">
-        ///     A function that accepts the existing argument's value and
-        ///     returns a new object to be used as the new argument's value.
+        ///     A function that accepts the existing argument's value and returns a new object to be
+        ///     used as the new argument's value.
         /// </param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception
-        ///     that will be thrown if the conversion function fails.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     conversion function fails.
         /// </param>
         /// <returns>A new <see cref="ArgumentInfo{TTarget}" />.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="convert" /> is <c>null</c>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="convert" /> threw an exception.
-        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="convert" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="convert" /> threw an exception.</exception>
+        [ContractAnnotation("convert:null => halt")]
         public static ArgumentInfo<TTarget> Wrap<TSource, TTarget>(
             in this ArgumentInfo<TSource> argument,
             Func<TSource, TTarget> convert,
@@ -85,9 +79,9 @@
         }
 
 #if !NETSTANDARD1_0
+
         /// <summary>
-        ///     Returns a new argument with the same name
-        ///     and a shallow clone of the original value.
+        ///     Returns a new argument with the same name and a shallow clone of the original value.
         /// </summary>
         /// <typeparam name="T">The type of the cloneable argument.</typeparam>
         /// <param name="argument">The cloneable argument.</param>
@@ -100,8 +94,8 @@
 
             return new ArgumentInfo<T>(
                 argument.Value.Clone() as T, argument.Name, argument.Modified, argument.Secure);
-
         }
+
 #endif
     }
 }

--- a/src/Guard.Null.cs
+++ b/src/Guard.Null.cs
@@ -1,7 +1,11 @@
-﻿namespace Dawn
+﻿using System.Diagnostics;
+
+namespace Dawn
 {
     using System;
     using System.Linq.Expressions;
+    using System.Runtime.CompilerServices;
+    using JetBrains.Annotations;
 
     /// <content>Nullability preconditions.</content>
     public static partial class Guard
@@ -10,13 +14,12 @@
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> is not <c>null</c>.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> is not <c>null</c>.</exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> Null<T>(
             in this ArgumentInfo<T> argument, Func<T, string> message = null)
             where T : class
@@ -34,26 +37,25 @@
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> is not <c>null</c>.
-        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="argument" /> is not <c>null</c>.</exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T?> Null<T>(
             in this ArgumentInfo<T?> argument, Func<T?, string> message = null)
             where T : struct
         {
             if (argument.HasValue())
             {
+                Debug.Assert(argument.Value.HasValue, "argument.HasValue");
                 var m = message?.Invoke(argument.Value.Value) ?? Messages.Null(argument);
                 throw new ArgumentException(m, argument.Name);
             }
@@ -65,18 +67,19 @@
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="argument" /> value is <c>null</c> and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <c>null</c> and the argument is not modified
+        ///     since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <c>null</c> and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <c>null</c> and the argument is modified after
+        ///     its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<T> NotNull<T>(
             in this ArgumentInfo<T> argument, string message = null)
             where T : class
@@ -96,18 +99,19 @@
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
-        ///     The factory to initialize the message of the exception that
-        ///     will be thrown if the precondition is not satisfied.
+        ///     The factory to initialize the message of the exception that will be thrown if the
+        ///     precondition is not satisfied.
         /// </param>
         /// <returns>A new <see cref="ArgumentInfo{T}" />.</returns>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="argument" /> value is <c>null</c> and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <c>null</c> and the argument is not modified
+        ///     since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <c>null</c> and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <c>null</c> and the argument is modified after
+        ///     its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ArgumentInfo<T> NotNull<T>(
             in this ArgumentInfo<T?> argument, string message = null)
             where T : struct
@@ -125,19 +129,18 @@
         }
 
         /// <summary>
-        ///     Initializes a new <see cref="ArgumentInfo{T}" />
-        ///     if the argument value is not <c>null</c>.
-        ///     A return value indicates whether the new argument is created.
+        ///     Initializes a new <see cref="ArgumentInfo{T}" /> if the argument value is not
+        ///     <c>null</c>. A return value indicates whether the new argument is created.
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="result">
-        ///     The new argument, if <paramref name="argument" /> is
-        ///     not <c>null</c>; otherwise, the uninitialized argument.
+        ///     The new argument, if <paramref name="argument" /> is not <c>null</c>; otherwise, the
+        ///     uninitialized argument.
         /// </param>
         /// <returns>
-        ///     <c>true</c>, if the <paramref name="argument" />
-        ///     is not <c>null</c>; otherwise, <c>false</c>.
+        ///     <c>true</c>, if the <paramref name="argument" /> is not <c>null</c>; otherwise, <c>false</c>.
         /// </returns>
+        [AssertionMethod]
         [Obsolete("Use the HasValue method to check against null.")]
         public static bool NotNull<T>(
             in this ArgumentInfo<T?> argument, out ArgumentInfo<T> result)
@@ -163,18 +166,25 @@
             ///     A function that determines whether a specified instance of type
             ///     <typeparamref name="T" /> is not <c>null</c>.
             /// </summary>
-            public static readonly IsNotNull HasValue = InitHasValue();
+            private static readonly IsNotNull hasValue = InitHasValue();
+
+            /// <summary>A delegate that checks whether an object is not <c>null</c>.</summary>
+            /// <param name="value">The value to check against <c>null</c>.</param>
+            /// <returns>
+            ///     <c>true</c>, if <paramref name="value" /> is not <c>null</c>; otherwise, <c>false</c>.
+            /// </returns>
+            private delegate bool IsNotNull(in T value);
 
             /// <summary>
-            ///     A delegate that checks whether an instance of <typeparamref name="T" /> is not
-            ///     <c>null</c>.
+            ///     Determines whether a specified instance of type <typeparamref name="T" /> is not <c>null</c>.
             /// </summary>
             /// <param name="value">The value to check against <c>null</c>.</param>
             /// <returns>
-            ///     <c>true</c>, if <paramref name="value" /> is not <c>null</c>; otherwise,
-            ///     <c>false</c>.
+            ///     <c>true</c>, if <paramref name="value" /> is not <c>null</c>; otherwise, <c>false</c>.
             /// </returns>
-            public delegate bool IsNotNull(in T value);
+            [ContractAnnotation("value:notnull => true; value:null => false")]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static bool HasValue(in T value) => hasValue(value);
 
             /// <summary>Initializes <see cref="HasValue" />.</summary>
             /// <returns>

--- a/src/Guard.Single.cs
+++ b/src/Guard.Single.cs
@@ -1,13 +1,14 @@
 ﻿namespace Dawn
 {
     using System;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="float" /> arguments.</content>
     public static partial class Guard
     {
         /// <summary>
-        ///     Requires the single-precision floating-point argument to have a value that is
-        ///     "not a number" (<see cref="float.NaN" />).
+        ///     Requires the single-precision floating-point argument to have a value that is "not a
+        ///     number" ( <see cref="float.NaN" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -16,13 +17,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not <see cref="float.NaN" />, and the
-        ///     argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not <see cref="float.NaN" />, and the argument
+        ///     is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <see cref="float.NaN" />, and the
-        ///     argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not <see cref="float.NaN" />, and the argument
+        ///     is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float> NaN(
             in this ArgumentInfo<float> argument, Func<float, string> message = null)
         {
@@ -39,7 +41,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is either
-        ///     <c>null</c> or "not a number" (<see cref="float.NaN" />).
+        ///     <c>null</c> or "not a number" ( <see cref="float.NaN" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -56,12 +58,12 @@
         ///     <see cref="float.NaN" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float?> NaN(
             in this ArgumentInfo<float?> argument, Func<float?, string> message = null)
         {
@@ -82,7 +84,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is not
-        ///     "not a number" (<see cref="float.NaN" />).
+        ///     "not a number" ( <see cref="float.NaN" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -97,6 +99,7 @@
         ///     <paramref name="argument" /> value is <see cref="float.NaN" />, and the argument is
         ///     modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float> NotNaN(
             in this ArgumentInfo<float> argument, string message = null)
         {
@@ -113,7 +116,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is not
-        ///     "not a number" (<see cref="float.NaN" />).
+        ///     "not a number" ( <see cref="float.NaN" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -128,6 +131,7 @@
         ///     <paramref name="argument" /> value is <see cref="float.NaN" />, and the argument is
         ///     modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float?> NotNaN(
             in this ArgumentInfo<float?> argument, string message = null)
         {
@@ -148,8 +152,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is either
-        ///     positive infinity (<see cref="float.PositiveInfinity" />) or negative infinity
-        ///     (<see cref="float.NegativeInfinity" />).
+        ///     positive infinity ( <see cref="float.PositiveInfinity" />) or negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -159,14 +162,14 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="argument" /> value is neither <see cref="float.PositiveInfinity" />
-        ///     nor <see cref="float.NegativeInfinity" />, and the argument is not modified since
-        ///     it is initialized.
+        ///     nor <see cref="float.NegativeInfinity" />, and the argument is not modified since it
+        ///     is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is neither <see cref="float.PositiveInfinity" />
-        ///     nor <see cref="float.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     nor <see cref="float.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float> Infinity(
             in this ArgumentInfo<float> argument, Func<float, string> message = null)
         {
@@ -183,8 +186,8 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is
-        ///     <c>null</c>, positive infinity (<see cref="float.PositiveInfinity" />) or negative
-        ///     infinity (<see cref="float.NegativeInfinity" />).
+        ///     <c>null</c>, positive infinity ( <see cref="float.PositiveInfinity" />) or negative
+        ///     infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -203,12 +206,12 @@
         ///     and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float?> Infinity(
             in this ArgumentInfo<float?> argument, Func<float?, string> message = null)
         {
@@ -228,9 +231,8 @@
         }
 
         /// <summary>
-        ///     Requires the single-precision floating-point argument to have a value that is
-        ///     neither positive infinity (<see cref="float.PositiveInfinity" />) nor negative
-        ///     infinity (<see cref="float.NegativeInfinity" />).
+        ///     Requires the single-precision floating-point argument to have a value that is neither
+        ///     positive infinity ( <see cref="float.PositiveInfinity" />) nor negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -238,15 +240,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" />
-        ///     or <see cref="float.NegativeInfinity" />, and the argument is not modified since it
-        ///     is initialized.
+        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" /> or
+        ///     <see cref="float.NegativeInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" />
-        ///     or <see cref="float.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" /> or
+        ///     <see cref="float.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         [Obsolete("Use the NotInfinity overload that accepts the message as a `Func<float, string>`.")]
         public static ref readonly ArgumentInfo<float> NotInfinity(
             in this ArgumentInfo<float> argument, string message)
@@ -263,9 +264,8 @@
         }
 
         /// <summary>
-        ///     Requires the single-precision floating-point argument to have a value that is
-        ///     neither positive infinity (<see cref="float.PositiveInfinity" />) nor negative
-        ///     infinity (<see cref="float.NegativeInfinity" />).
+        ///     Requires the single-precision floating-point argument to have a value that is neither
+        ///     positive infinity ( <see cref="float.PositiveInfinity" />) nor negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -274,15 +274,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" />
-        ///     or <see cref="float.NegativeInfinity" />, and the argument is not modified since it
-        ///     is initialized.
+        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" /> or
+        ///     <see cref="float.NegativeInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" />
-        ///     or <see cref="float.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" /> or
+        ///     <see cref="float.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float> NotInfinity(
             in this ArgumentInfo<float> argument, Func<float, string> message = null)
         {
@@ -298,9 +297,8 @@
         }
 
         /// <summary>
-        ///     Requires the single-precision floating-point argument to have a value that is
-        ///     neither positive infinity (<see cref="float.PositiveInfinity" />) nor negative
-        ///     infinity (<see cref="float.NegativeInfinity" />).
+        ///     Requires the single-precision floating-point argument to have a value that is neither
+        ///     positive infinity ( <see cref="float.PositiveInfinity" />) nor negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -308,15 +306,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" />
-        ///     or <see cref="float.NegativeInfinity" />, and the argument is not modified since it
-        ///     is initialized.
+        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" /> or
+        ///     <see cref="float.NegativeInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" />
-        ///     or <see cref="float.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" /> or
+        ///     <see cref="float.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         [Obsolete("Use the NotInfinity overload that accepts the message as a `Func<float?, string>`.")]
         public static ref readonly ArgumentInfo<float?> NotInfinity(
             in this ArgumentInfo<float?> argument, string message)
@@ -333,9 +330,8 @@
         }
 
         /// <summary>
-        ///     Requires the single-precision floating-point argument to have a value that is
-        ///     neither positive infinity (<see cref="float.PositiveInfinity" />) nor negative
-        ///     infinity (<see cref="float.NegativeInfinity" />).
+        ///     Requires the single-precision floating-point argument to have a value that is neither
+        ///     positive infinity ( <see cref="float.PositiveInfinity" />) nor negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -344,22 +340,20 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" />
-        ///     or <see cref="float.NegativeInfinity" />, and the argument is not modified since it
-        ///     is initialized.
+        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" /> or
+        ///     <see cref="float.NegativeInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" />
-        ///     or <see cref="float.NegativeInfinity" />, and the argument is modified after its
-        ///     initialization.
+        ///     <paramref name="argument" /> value is either <see cref="float.PositiveInfinity" /> or
+        ///     <see cref="float.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float?> NotInfinity(
             in this ArgumentInfo<float?> argument, Func<float?, string> message = null)
         {
@@ -380,7 +374,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is
-        ///     positive infinity (<see cref="float.PositiveInfinity" />).
+        ///     positive infinity ( <see cref="float.PositiveInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -389,13 +383,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not <see cref="float.PositiveInfinity" />,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not <see cref="float.PositiveInfinity" />, and
+        ///     the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <see cref="float.PositiveInfinity" />,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not <see cref="float.PositiveInfinity" />, and
+        ///     the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float> PositiveInfinity(
             in this ArgumentInfo<float> argument, Func<float, string> message = null)
         {
@@ -412,7 +407,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is either
-        ///     <c>null</c> or positive infinity (<see cref="float.PositiveInfinity" />).
+        ///     <c>null</c> or positive infinity ( <see cref="float.PositiveInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -422,21 +417,19 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor
-        ///     <see cref="float.PositiveInfinity" />, and the argument is not modified
-        ///     since it is initialized.
+        ///     <see cref="float.PositiveInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor
-        ///     <see cref="float.PositiveInfinity" />, and the argument is modified
-        ///     after its initialization.
+        ///     <see cref="float.PositiveInfinity" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float?> PositiveInfinity(
             in this ArgumentInfo<float?> argument, Func<float?, string> message = null)
         {
@@ -457,7 +450,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is not
-        ///     positive infinity (<see cref="float.PositiveInfinity" />).
+        ///     positive infinity ( <see cref="float.PositiveInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -465,13 +458,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is <see cref="float.PositiveInfinity" />, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <see cref="float.PositiveInfinity" />, and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <see cref="float.PositiveInfinity" />, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <see cref="float.PositiveInfinity" />, and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float> NotPositiveInfinity(
             in this ArgumentInfo<float> argument, string message = null)
         {
@@ -488,7 +482,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is not
-        ///     positive infinity (<see cref="float.PositiveInfinity" />).
+        ///     positive infinity ( <see cref="float.PositiveInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -496,13 +490,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is <see cref="float.PositiveInfinity" />, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <see cref="float.PositiveInfinity" />, and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <see cref="float.PositiveInfinity" />, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <see cref="float.PositiveInfinity" />, and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float?> NotPositiveInfinity(
             in this ArgumentInfo<float?> argument, string message = null)
         {
@@ -523,7 +518,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is
-        ///     negative infinity (<see cref="float.NegativeInfinity" />).
+        ///     negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -532,13 +527,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is not <see cref="float.NegativeInfinity" />,
-        ///     and the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is not <see cref="float.NegativeInfinity" />, and
+        ///     the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <see cref="float.NegativeInfinity" />,
-        ///     and the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is not <see cref="float.NegativeInfinity" />, and
+        ///     the argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float> NegativeInfinity(
             in this ArgumentInfo<float> argument, Func<float, string> message = null)
         {
@@ -555,7 +551,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is either
-        ///     <c>null</c> or negative infinity (<see cref="float.NegativeInfinity" />).
+        ///     <c>null</c> or negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -565,21 +561,19 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor
-        ///     <see cref="float.NegativeInfinity" />, and the argument is not
-        ///     modified since it is initialized.
+        ///     <see cref="float.NegativeInfinity" />, and the argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor
-        ///     <see cref="float.NegativeInfinity" />, and the argument is
-        ///     modified after its initialization.
+        ///     <see cref="float.NegativeInfinity" />, and the argument is modified after its initialization.
         /// </exception>
         /// <remarks>
-        ///     The argument value that is passed to <paramref name="message" />
-        ///     cannot be <c>null</c>, but it is defined as nullable anyway.
-        ///     This is because passing a lambda would cause the calls
-        ///     to be ambiguous between this method and its overload
-        ///     when the message delegate accepts a non-nullable argument.
+        ///     The argument value that is passed to <paramref name="message" /> cannot be
+        ///     <c>null</c>, but it is defined as nullable anyway. This is because passing a lambda
+        ///     would cause the calls to be ambiguous between this method and its overload when the
+        ///     message delegate accepts a non-nullable argument.
         /// </remarks>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float?> NegativeInfinity(
             in this ArgumentInfo<float?> argument, Func<float?, string> message = null)
         {
@@ -600,7 +594,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is not
-        ///     negative infinity (<see cref="float.NegativeInfinity" />).
+        ///     negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -608,13 +602,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is <see cref="float.NegativeInfinity" />, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <see cref="float.NegativeInfinity" />, and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <see cref="float.NegativeInfinity" />, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <see cref="float.NegativeInfinity" />, and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float> NotNegativeInfinity(
             in this ArgumentInfo<float> argument, string message = null)
         {
@@ -631,7 +626,7 @@
 
         /// <summary>
         ///     Requires the single-precision floating-point argument to have a value that is not
-        ///     negative infinity (<see cref="float.NegativeInfinity" />).
+        ///     negative infinity ( <see cref="float.NegativeInfinity" />).
         /// </summary>
         /// <param name="argument">The argument.</param>
         /// <param name="message">
@@ -639,13 +634,14 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="argument" /> value is <see cref="float.NegativeInfinity" />, and
-        ///     the argument is not modified since it is initialized.
+        ///     <paramref name="argument" /> value is <see cref="float.NegativeInfinity" />, and the
+        ///     argument is not modified since it is initialized.
         /// </exception>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is <see cref="float.NegativeInfinity" />, and
-        ///     the argument is modified after its initialization.
+        ///     <paramref name="argument" /> value is <see cref="float.NegativeInfinity" />, and the
+        ///     argument is modified after its initialization.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<float?> NotNegativeInfinity(
             in this ArgumentInfo<float?> argument, string message = null)
         {

--- a/src/Guard.String.cs
+++ b/src/Guard.String.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
     using System.Text.RegularExpressions;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="string" /> arguments.</content>
     public static partial class Guard
@@ -16,9 +17,9 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <c>null</c> and contains one or
-        ///     more characters.
+        ///     <paramref name="argument" /> value is not <c>null</c> and contains one or more characters.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> Empty(
             in this ArgumentInfo<string> argument, Func<string, string> message)
         {
@@ -39,9 +40,9 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <c>null</c> and does not contain
-        ///     any characters.
+        ///     <paramref name="argument" /> value is not <c>null</c> and does not contain any characters.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> NotEmpty(
             in this ArgumentInfo<string> argument, string message = null)
         {
@@ -55,8 +56,7 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a string value that consists only of
-        ///     white-space characters.
+        ///     Requires the argument to have a string value that consists only of white-space characters.
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="message">
@@ -68,6 +68,7 @@
         ///     <paramref name="argument" /> value is not <c>null</c> and contains one or more
         ///     characters that are not white-space.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> WhiteSpace(
             in this ArgumentInfo<string> argument, Func<string, string> message = null)
         {
@@ -91,9 +92,10 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <c>null</c>
-        ///     and contains only of white-space characters.
+        ///     <paramref name="argument" /> value is not <c>null</c> and contains only of
+        ///     white-space characters.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> NotWhiteSpace(
             in this ArgumentInfo<string> argument, Func<string, string> message = null)
         {
@@ -123,6 +125,7 @@
         ///     <paramref name="argument" /> value is not <c>null</c> and contains less than the
         ///     specified number of characters.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> MinLength(
             in this ArgumentInfo<string> argument,
             int minLength,
@@ -139,8 +142,8 @@
         }
 
         /// <summary>
-        ///     Requires the argument to have a string value that contains no more than the
-        ///     specified number of characters.
+        ///     Requires the argument to have a string value that contains no more than the specified
+        ///     number of characters.
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="maxLength">
@@ -155,6 +158,7 @@
         ///     <paramref name="argument" /> value is not <c>null</c> and contains more than the
         ///     specified number of characters.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> MaxLength(
             in this ArgumentInfo<string> argument,
             int maxLength,
@@ -187,9 +191,9 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is not <c>null</c> and contains either less than
-        ///     <paramref name="minLength" /> or more than <paramref name="maxLength" /> number
-        ///     of characters.
+        ///     <paramref name="minLength" /> or more than <paramref name="maxLength" /> number of characters.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> LengthInRange(
             in this ArgumentInfo<string> argument,
             int minLength,
@@ -214,9 +218,7 @@
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="other">The string to compare the argument value to.</param>
-        /// <param name="comparison">
-        ///     The rules that specify how the strings will be compared.
-        /// </param>
+        /// <param name="comparison">The rules that specify how the strings will be compared.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
@@ -226,6 +228,7 @@
         ///     <paramref name="argument" /> value is not equal to <paramref name="other" /> by the
         ///     comparison rules specified in <paramref name="comparison" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> Equal(
             in this ArgumentInfo<string> argument,
             string other,
@@ -247,9 +250,7 @@
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="other">The string to compare the argument value to.</param>
-        /// <param name="comparison">
-        ///     The rules that specify how the strings will be compared.
-        /// </param>
+        /// <param name="comparison">The rules that specify how the strings will be compared.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
@@ -259,6 +260,7 @@
         ///     <paramref name="argument" /> value is equal to <paramref name="other" /> by the
         ///     comparison rules specified in <paramref name="comparison" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> NotEqual(
             in this ArgumentInfo<string> argument,
             string other,
@@ -285,9 +287,10 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value does not start with <paramref name="value" />
-        ///     when a case-sensitive and culture-sensitive comparison is performed.
+        ///     <paramref name="argument" /> value does not start with <paramref name="value" /> when
+        ///     a case-sensitive and culture-sensitive comparison is performed.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<string> StartsWith(
             in this ArgumentInfo<string> argument,
@@ -296,23 +299,22 @@
             => ref argument.StartsWith(value, StringComparison.CurrentCulture, message);
 
         /// <summary>
-        ///     Requires the beginning of the string argument to match with the specified string
-        ///     when compared by the specified rules.
+        ///     Requires the beginning of the string argument to match with the specified string when
+        ///     compared by the specified rules.
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="value">The string to search in the beginning of the argument.</param>
-        /// <param name="comparison">
-        ///     The rules that specify how the strings will be compared.
-        /// </param>
+        /// <param name="comparison">The rules that specify how the strings will be compared.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value does not start with <paramref name="value" />
-        ///     when compared by the comparison rules specified in <paramref name="comparison" />.
+        ///     <paramref name="argument" /> value does not start with <paramref name="value" /> when
+        ///     compared by the comparison rules specified in <paramref name="comparison" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> StartsWith(
             in this ArgumentInfo<string> argument,
             string value,
@@ -329,8 +331,7 @@
         }
 
         /// <summary>
-        ///     Requires the beginning of the string argument to be different than the
-        ///     specified string.
+        ///     Requires the beginning of the string argument to be different than the specified string.
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="value">The string to search in the beginning of the argument.</param>
@@ -343,6 +344,7 @@
         ///     <paramref name="argument" /> value starts with <paramref name="value" /> when a
         ///     case-sensitive and culture-sensitive comparison is performed.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<string> DoesNotStartWith(
             in this ArgumentInfo<string> argument,
@@ -356,9 +358,7 @@
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="value">The string to search in the beginning of the argument.</param>
-        /// <param name="comparison">
-        ///     The rules that specify how the strings will be compared.
-        /// </param>
+        /// <param name="comparison">The rules that specify how the strings will be compared.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
@@ -368,6 +368,7 @@
         ///     <paramref name="argument" /> value starts with <paramref name="value" /> when
         ///     compared by the comparison rules specified in <paramref name="comparison" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> DoesNotStartWith(
             in this ArgumentInfo<string> argument,
             string value,
@@ -394,9 +395,10 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value does not end with <paramref name="value" /> when
-        ///     a case-sensitive and culture-sensitive comparison is performed.
+        ///     <paramref name="argument" /> value does not end with <paramref name="value" /> when a
+        ///     case-sensitive and culture-sensitive comparison is performed.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<string> EndsWith(
             in this ArgumentInfo<string> argument,
@@ -410,9 +412,7 @@
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="value">The string to search in the end of the argument.</param>
-        /// <param name="comparison">
-        ///     The rules that specify how the strings will be compared.
-        /// </param>
+        /// <param name="comparison">The rules that specify how the strings will be compared.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
@@ -422,6 +422,7 @@
         ///     <paramref name="argument" /> value does not end with <paramref name="value" /> when
         ///     compared by the comparison rules specified in <paramref name="comparison" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> EndsWith(
             in this ArgumentInfo<string> argument,
             string value,
@@ -451,6 +452,7 @@
         ///     <paramref name="argument" /> value ends with <paramref name="value" /> when a
         ///     case-sensitive and culture-sensitive comparison is performed.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<string> DoesNotEndWith(
             in this ArgumentInfo<string> argument,
@@ -464,9 +466,7 @@
         /// </summary>
         /// <param name="argument">The string argument.</param>
         /// <param name="value">The string to search in the end of the argument.</param>
-        /// <param name="comparison">
-        ///     The rules that specify how the strings will be compared.
-        /// </param>
+        /// <param name="comparison">The rules that specify how the strings will be compared.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
@@ -476,6 +476,7 @@
         ///     <paramref name="argument" /> value ends with <paramref name="value" /> when compared
         ///     by the comparison rules specified in <paramref name="comparison" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> DoesNotEndWith(
             in this ArgumentInfo<string> argument,
             string value,
@@ -506,9 +507,10 @@
         ///     <paramref name="pattern" /> cannot be parsed as a regular expression, or the
         ///     resulting expression could not find a match in <paramref name="argument" />'s value.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> Matches(
             in this ArgumentInfo<string> argument,
-            string pattern,
+            [RegexPattern] string pattern,
             Func<string, bool, string> message = null)
         {
             if (argument.HasValue() && pattern != null)
@@ -553,16 +555,15 @@
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
         ///     <paramref name="pattern" /> cannot be parsed as a regular expression, the resulting
-        ///     expression timed out, or it could not find a match in <paramref name="argument" />'s
-        ///     value.
+        ///     expression timed out, or it could not find a match in <paramref name="argument" />'s value.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="matchTimeout" /> is negative, zero, or greater than approximately
-        ///     24 days.
+        ///     <paramref name="matchTimeout" /> is negative, zero, or greater than approximately 24 days.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> Matches(
             in this ArgumentInfo<string> argument,
-            string pattern,
+            [RegexPattern] string pattern,
             TimeSpan matchTimeout,
             Func<string, bool, string> message = null)
         {
@@ -613,6 +614,7 @@
         ///     <paramref name="regex" /> could not find a match in <paramref name="argument" />'s
         ///     value or it timed out before the evaluation is completed.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> Matches(
             in this ArgumentInfo<string> argument,
             Regex regex,
@@ -661,9 +663,10 @@
         ///     <paramref name="pattern" /> cannot be parsed as a regular expression, or the
         ///     resulting expression found a match in <paramref name="argument" />'s value.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> DoesNotMatch(
             in this ArgumentInfo<string> argument,
-            string pattern,
+            [RegexPattern] string pattern,
             Func<string, bool, string> message = null)
         {
             if (argument.HasValue() && pattern != null)
@@ -712,12 +715,12 @@
         ///     expression timed out, or it found a match in <paramref name="argument" />'s value.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///     <paramref name="matchTimeout" /> is negative, zero, or greater than approximately
-        ///     24 days.
+        ///     <paramref name="matchTimeout" /> is negative, zero, or greater than approximately 24 days.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> DoesNotMatch(
             in this ArgumentInfo<string> argument,
-            string pattern,
+            [RegexPattern] string pattern,
             TimeSpan matchTimeout,
             Func<string, bool, string> message = null)
         {
@@ -766,9 +769,10 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="regex" /> found a match in <paramref name="argument" />'s value or
-        ///     it timed out before the evaluation is completed.
+        ///     <paramref name="regex" /> found a match in <paramref name="argument" />'s value or it
+        ///     timed out before the evaluation is completed.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<string> DoesNotMatch(
             in this ArgumentInfo<string> argument,
             Regex regex,
@@ -802,8 +806,7 @@
         }
 
         /// <summary>
-        ///     Returns the string comparer that is most
-        ///     relevant to the specified enumeration value.
+        ///     Returns the string comparer that is most relevant to the specified enumeration value.
         /// </summary>
         /// <param name="comparison">
         ///     An enumeration value that specifies how to compare two strings.

--- a/src/Guard.Types.cs
+++ b/src/Guard.Types.cs
@@ -4,13 +4,13 @@
     using System.Collections.Generic;
     using System.Linq.Expressions;
     using System.Threading;
+    using JetBrains.Annotations;
 
     /// <content>Provides type preconditions.</content>
     public static partial class Guard
     {
         /// <summary>
-        ///     Requires the argument to have a value that is an instance of the specified
-        ///     generic type.
+        ///     Requires the argument to have a value that is an instance of the specified generic type.
         /// </summary>
         /// <typeparam name="T">
         ///     The type that the argument's value should be an instance of.
@@ -22,9 +22,9 @@
         /// </param>
         /// <returns>A new <see cref="ArgumentInfo{T}" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not an instance of type
-        ///     <typeparamref name="T" />.
+        ///     <paramref name="argument" /> value is not an instance of type <typeparamref name="T" />.
         /// </exception>
+        [AssertionMethod]
         public static ArgumentInfo<T> Type<T>(
             in this ArgumentInfo<object> argument, Func<object, string> message = null)
         {
@@ -54,6 +54,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is an instance of type <typeparamref name="T" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<object> NotType<T>(
             in this ArgumentInfo<object> argument, Func<T, string> message = null)
         {
@@ -70,18 +71,16 @@
         ///     Requires the argument to have a value that is an instance of the specified type.
         /// </summary>
         /// <param name="argument">The object argument.</param>
-        /// <param name="type">
-        ///     The type that the argument's value should be an instance of.
-        /// </param>
+        /// <param name="type">The type that the argument's value should be an instance of.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
         ///     precondition is not satisfied.
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not an instance of the type represented by
-        ///     <paramref name="type" />.
+        ///     <paramref name="argument" /> value is not an instance of the type represented by <paramref name="type" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<object> Type(
             in this ArgumentInfo<object> argument, Type type, Func<object, Type, string> message = null)
         {
@@ -107,9 +106,9 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is an instance of the type represented by
-        ///     <paramref name="type" />.
+        ///     <paramref name="argument" /> value is an instance of the type represented by <paramref name="type" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<object> NotType(
             in this ArgumentInfo<object> argument, Type type, Func<object, Type, string> message = null)
         {
@@ -127,15 +126,13 @@
         private static class TypeInfo<T>
         {
             /// <summary>
-            ///     A function that determines whether the specified object can be converted to type
-            ///     <typeparamref name="T" />.
+            ///     A function that determines whether the specified object can be converted to type <typeparamref name="T" />.
             /// </summary>
             public static readonly Func<object, bool> CanBeInitializedFrom = InitCanBeInitializedFrom();
 
             /// <summary>Initializes <see cref="CanBeInitializedFrom" />.</summary>
             /// <returns>
-            ///     A function that determines whether the specified object can be converted to type
-            ///     <typeparamref name="T" />.
+            ///     A function that determines whether the specified object can be converted to type <typeparamref name="T" />.
             /// </returns>
             private static Func<object, bool> InitCanBeInitializedFrom()
             {
@@ -162,9 +159,7 @@
         /// <summary>Provides non-generic, cached utilities for specified types.</summary>
         private static class TypeInfo
         {
-            /// <summary>
-            ///     The locker that synchronizes access to <see cref="canBeConvertedTo" />.
-            /// </summary>
+            /// <summary>The locker that synchronizes access to <see cref="canBeConvertedTo" />.</summary>
             private static readonly ReaderWriterLockSlim locker
                 = new ReaderWriterLockSlim();
 
@@ -176,18 +171,14 @@
                 = new Dictionary<Type, Func<object, bool>>();
 
             /// <summary>
-            ///     Determines whether an object can be converted to an instance of the
-            ///     specified type.
+            ///     Determines whether an object can be converted to an instance of the specified type.
             /// </summary>
             /// <param name="obj">The object to check.</param>
             /// <param name="targetType">The type to check.</param>
             /// <returns>
-            ///     <c>true</c>, if <paramref name="obj" /> can be converted to an instance of
-            ///     <paramref name="targetType" />.
+            ///     <c>true</c>, if <paramref name="obj" /> can be converted to an instance of <paramref name="targetType" />.
             /// </returns>
-            /// <remarks>
-            ///     Calls <see cref="TypeInfo{T}.CanBeInitializedFrom" />.
-            /// </remarks>
+            /// <remarks>Calls <see cref="TypeInfo{T}.CanBeInitializedFrom" />.</remarks>
             public static bool CanBeConvertedTo(object obj, Type targetType)
             {
                 Func<object, bool> func;

--- a/src/Guard.Uri.cs
+++ b/src/Guard.Uri.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Runtime.CompilerServices;
+    using JetBrains.Annotations;
 
     /// <content>Provides preconditions for <see cref="Uri" /> arguments.</content>
     public static partial class Guard
@@ -22,6 +23,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor an absolute URI.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<Uri> Absolute(
             in this ArgumentInfo<Uri> argument, Func<Uri, string> message = null)
         {
@@ -44,6 +46,7 @@
         /// <exception cref="ArgumentException">
         ///     <paramref name="argument" /> value is neither <c>null</c> nor a relative URI.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<Uri> Relative(
             in this ArgumentInfo<Uri> argument, Func<Uri, string> message = null)
         {
@@ -70,6 +73,7 @@
         ///     <paramref name="argument" /> value is neither <c>null</c> nor an absolute URI with
         ///     the scheme specified by <paramref name="scheme" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<Uri> Scheme(
             in this ArgumentInfo<Uri> argument, string scheme, Func<Uri, string, string> message = null)
         {
@@ -95,9 +99,9 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is an absolute URI with the scheme specified by
-        ///     <paramref name="scheme" />.
+        ///     <paramref name="argument" /> value is an absolute URI with the scheme specified by <paramref name="scheme" />.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<Uri> NotScheme(
             in this ArgumentInfo<Uri> argument, string scheme, Func<Uri, string, string> message = null)
         {
@@ -125,6 +129,7 @@
         ///     <paramref name="argument" /> value is not <c>null</c> and its scheme is neither HTTP
         ///     nor HTTPS.
         /// </exception>
+        [AssertionMethod]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref readonly ArgumentInfo<Uri> Http(
             in this ArgumentInfo<Uri> argument, Func<Uri, string> message = null)
@@ -147,6 +152,7 @@
         ///     <paramref name="argument" /> value is not <c>null</c> and does not have one of the
         ///     required schemes.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<Uri> Http(
             in this ArgumentInfo<Uri> argument, bool allowHttps, Func<Uri, string> message = null)
         {
@@ -166,9 +172,7 @@
             throw new ArgumentException(m, argument.Name);
         }
 
-        /// <summary>
-        ///     Requires the argument value to be an absolute URI with the HTTPS scheme.
-        /// </summary>
+        /// <summary>Requires the argument value to be an absolute URI with the HTTPS scheme.</summary>
         /// <param name="argument">The URI argument.</param>
         /// <param name="message">
         ///     The factory to initialize the message of the exception that will be thrown if the
@@ -176,9 +180,9 @@
         /// </param>
         /// <returns><paramref name="argument" />.</returns>
         /// <exception cref="ArgumentException">
-        ///     <paramref name="argument" /> value is not <c>null</c> and does not have the
-        ///     HTTPS scheme.
+        ///     <paramref name="argument" /> value is not <c>null</c> and does not have the HTTPS scheme.
         /// </exception>
+        [AssertionMethod]
         public static ref readonly ArgumentInfo<Uri> Https(
             in this ArgumentInfo<Uri> argument, Func<Uri, string> message = null)
         {

--- a/src/Guard.csproj
+++ b/src/Guard.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
     <AssemblyName>Dawn.Guard</AssemblyName>
     <Product>Dawn Utils</Product>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <FileVersion>1.0.0</FileVersion>
     <RootNamespace>Dawn</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Properties/Annotations.cs
+++ b/src/Properties/Annotations.cs
@@ -1,0 +1,45 @@
+﻿namespace JetBrains.Annotations
+{
+    using System;
+
+    /// <summary>
+    ///     Indicates that the marked method is an assertion method, i.e. it halts the control flow
+    ///     unless a condition is satisfied.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class AssertionMethodAttribute : Attribute { }
+
+    /// <summary>Describes the relations between the marked method's inputs and outputs.</summary>
+    /// <see href="https://www.jetbrains.com/help/resharper/Contract_Annotations.html" />
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    internal sealed class ContractAnnotationAttribute : Attribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ContractAnnotationAttribute" /> class.
+        /// </summary>
+        /// <param name="contract">The contract string.</param>
+        public ContractAnnotationAttribute([NotNull] string contract) => this.Contract = contract;
+
+        /// <summary>Gets the contract string.</summary>
+        [NotNull]
+        public string Contract { get; }
+    }
+
+    /// <summary>
+    ///     Indicates that the marked argument should be a string literal and match one of the
+    ///     parameters of the method it belongs to.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class InvokerParameterNameAttribute : Attribute { }
+
+    /// <summary>Indicates that the value of the marked element could never be <c>null</c>.</summary>
+    [AttributeUsage(
+      AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property |
+      AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event |
+      AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.GenericParameter)]
+    internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Indicates that the marked parameter is a regular expression pattern.</summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class RegexPatternAttribute : Attribute { }
+}

--- a/tests/EnumerableTests.cs
+++ b/tests/EnumerableTests.cs
@@ -699,7 +699,7 @@
                 }
                 else
                 {
-                    throw new NotImplementedException();
+                    throw new NotSupportedException();
                 }
             }
 

--- a/tests/Guard.Tests.csproj
+++ b/tests/Guard.Tests.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1-pre.build.4059" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1-pre.build.4059" />
     <PackageReference Include="coverlet.msbuild" Version="2.2.1" />
   </ItemGroup>
 

--- a/tests/InitializationTests.cs
+++ b/tests/InitializationTests.cs
@@ -120,11 +120,54 @@
                     : i == 7 ? new Guard.ArgumentInfo<T>(value, null, false, true)
                              : new Guard.ArgumentInfo<T>(value, null, true, true);
 
-
                 Assert.Equal(value, arg.Value);
                 Assert.Contains(typeof(T).ToString(), arg.Name);
                 Assert.Equal(i == 2 || i == 5 || i == 8, arg.Modified);
                 Assert.Equal(i == 6 || i == 7 || i == 8, arg.Secure);
+            }
+        }
+
+        [Theory(DisplayName = T + "Argument: ToString")]
+        [InlineData(null)]
+        [InlineData(1)]
+        [InlineData("S")]
+        public void ConvertToString<T>(T value)
+        {
+            var valueArg = Guard.Argument(() => value);
+            if (valueArg.HasValue())
+                Assert.Equal(value.ToString(), valueArg.ToString());
+            else
+                Assert.Same(string.Empty, valueArg.ToString());
+        }
+
+        [Theory(DisplayName = T + "Argument: DebuggerDisplay")]
+        [InlineData(null)]
+        [InlineData(1)]
+        [InlineData("S")]
+        public void DebuggerDisplay<T>(T value)
+        {
+            const StringComparison ignoreCase = StringComparison.OrdinalIgnoreCase;
+            for (var i = 0; i < 3; i++)
+            {
+                var hasName = i <= 1;
+                var isSecure = i >= 1;
+                var valueArg = Guard.Argument(value, hasName ? nameof(value) : null, isSecure);
+
+                var display = valueArg.DebuggerDisplay;
+                if (hasName)
+                    Assert.Contains(nameof(value), display);
+                else
+                    Assert.DoesNotContain(nameof(value), display);
+
+                if (isSecure)
+                    Assert.Contains("SECURE", display, ignoreCase);
+                else
+                    Assert.DoesNotContain("SECURE", display, ignoreCase);
+
+                if (valueArg.HasValue())
+                    Assert.Contains(value.ToString(), display);
+                else
+                    Assert.Contains("NULL", display, ignoreCase);
             }
         }
     }

--- a/tests/MemberTests.cs
+++ b/tests/MemberTests.cs
@@ -57,7 +57,6 @@
             }
 
             var dateTime = nullableDateTime.Value;
-            var timeOfDay = dateTime.TimeOfDay;
 
             var innerException = null as Exception;
             var thrown = ThrowsArgumentException(


### PR DESCRIPTION
`NotIn` overload that accepts a `params` array must have been public. This version makes it so.