### PR TITLE
Added support for exception interceptors

### DIFF
--- a/src/Guard.Boolean.cs
+++ b/src/Guard.Boolean.cs
@@ -23,7 +23,7 @@
             if (!argument.Value)
             {
                 var m = message ?? Messages.True(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -45,7 +45,7 @@
             if (argument.HasValue() && !argument.Value.Value)
             {
                 var m = message ?? Messages.True(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -67,7 +67,7 @@
             if (argument.Value)
             {
                 var m = message ?? Messages.False(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -89,7 +89,7 @@
             if (argument.HasValue() && argument.Value.Value)
             {
                 var m = message ?? Messages.False(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;

--- a/src/Guard.Double.cs
+++ b/src/Guard.Double.cs
@@ -34,9 +34,9 @@
             if (!double.IsNaN(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NaN(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -78,9 +78,9 @@
                 if (!double.IsNaN(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.NaN(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -113,9 +113,9 @@
             if (double.IsNaN(argument.Value))
             {
                 var m = message ?? Messages.NotNaN(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -150,9 +150,9 @@
                 if (double.IsNaN(value))
                 {
                     var m = message ?? Messages.NotNaN(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -187,9 +187,9 @@
             if (!double.IsInfinity(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Infinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -234,9 +234,9 @@
                 if (!double.IsInfinity(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.Infinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -270,9 +270,9 @@
             if (double.IsInfinity(argument.Value))
             {
                 var m = message ?? Messages.NotInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -306,9 +306,9 @@
             if (double.IsInfinity(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NotInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -341,9 +341,9 @@
             if (argument.NotNull(out var a) && double.IsInfinity(a.Value))
             {
                 var m = message ?? Messages.NotInfinity(a);
-                throw !a.Modified
+                throw argument.Exception(!a.Modified
                     ? new ArgumentOutOfRangeException(a.Name, argument.Secure ? null : a.Value as object, m)
-                    : new ArgumentException(m, a.Name);
+                    : new ArgumentException(m, a.Name));
             }
 
             return ref argument;
@@ -386,9 +386,9 @@
                 if (double.IsInfinity(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.NotInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -422,9 +422,9 @@
             if (!double.IsPositiveInfinity(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.PositiveInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -466,9 +466,9 @@
                 if (!double.IsPositiveInfinity(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.PositiveInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -501,9 +501,9 @@
             if (double.IsPositiveInfinity(argument.Value))
             {
                 var m = message ?? Messages.NotPositiveInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -538,9 +538,9 @@
                 if (double.IsPositiveInfinity(value))
                 {
                     var m = message ?? Messages.NotPositiveInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -574,9 +574,9 @@
             if (!double.IsNegativeInfinity(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NegativeInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -618,9 +618,9 @@
                 if (!double.IsNegativeInfinity(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.NegativeInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -653,9 +653,9 @@
             if (double.IsNegativeInfinity(argument.Value))
             {
                 var m = message ?? Messages.NotNegativeInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -690,9 +690,9 @@
                 if (double.IsNegativeInfinity(value))
                 {
                     var m = message ?? Messages.NotNegativeInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -728,9 +728,9 @@
             if (diff > delta)
             {
                 var m = message?.Invoke(argument.Value, other) ?? Messages.Equal(argument, other, delta);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -768,9 +768,9 @@
                 if (diff > delta)
                 {
                     var m = message?.Invoke(value, other) ?? Messages.Equal(argument, other, delta);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -806,9 +806,9 @@
             if (diff <= delta)
             {
                 var m = message?.Invoke(argument.Value, other) ?? Messages.NotEqual(argument, other, delta);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -846,9 +846,9 @@
                 if (diff <= delta)
                 {
                     var m = message?.Invoke(value, other) ?? Messages.NotEqual(argument, other, delta);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 

--- a/src/Guard.Email.cs
+++ b/src/Guard.Email.cs
@@ -34,7 +34,7 @@ namespace Dawn
                 !argument.Value.Host.Equals(host, StringComparison.OrdinalIgnoreCase))
             {
                 var m = message?.Invoke(argument.Value, host) ?? Messages.EmailHasHost(argument, host);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -63,7 +63,7 @@ namespace Dawn
                 argument.Value.Host.Equals(host, StringComparison.OrdinalIgnoreCase))
             {
                 var m = message?.Invoke(argument.Value, host) ?? Messages.EmailDoesNotHaveHost(argument, host);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -94,7 +94,7 @@ namespace Dawn
                 !Collection<TCollection>.Typed<string>.Contains(hosts, argument.Value.Host, null))
             {
                 var m = message?.Invoke(argument.Value, hosts) ?? Messages.EmailHostIn(argument, hosts);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -125,7 +125,7 @@ namespace Dawn
                 Collection<TCollection>.Typed<string>.Contains(hosts, argument.Value.Host, null))
             {
                 var m = message?.Invoke(argument.Value, hosts) ?? Messages.EmailHostNotIn(argument, hosts);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -150,7 +150,7 @@ namespace Dawn
             if (argument.HasValue() && argument.Value.DisplayName.Length == 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.EmailHasDisplayName(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -175,7 +175,7 @@ namespace Dawn
             if (argument.HasValue() && argument.Value.DisplayName.Length > 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.EmailDoesNotHaveDisplayName(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;

--- a/src/Guard.Enums.Legacy.cs
+++ b/src/Guard.Enums.Legacy.cs
@@ -482,7 +482,8 @@
                             this.Argument.Value.Value,
                             this.Argument.Name,
                             this.Argument.Modified,
-                            this.Argument.Secure));
+                            this.Argument.Secure,
+                            this.Argument.ExceptionInterceptor));
 
                     return true;
                 }

--- a/src/Guard.Enums.cs
+++ b/src/Guard.Enums.cs
@@ -31,7 +31,7 @@
             if (!EnumInfo<T>.Values.Contains(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.EnumDefined(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -64,7 +64,7 @@
                 if (!EnumInfo<T>.Values.Contains(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.EnumDefined(argument);
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -95,7 +95,7 @@
             if (!EnumInfo<T>.HasFlag(argument.Value, flag))
             {
                 var m = message?.Invoke(argument.Value, flag) ?? Messages.EnumHasFlag(argument, flag);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -129,7 +129,7 @@
                 if (!EnumInfo<T>.HasFlag(value, flag))
                 {
                     var m = message?.Invoke(value, flag) ?? Messages.EnumHasFlag(argument, flag);
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -160,7 +160,7 @@
             if (EnumInfo<T>.HasFlag(argument.Value, flag))
             {
                 var m = message?.Invoke(argument.Value, flag) ?? Messages.EnumDoesNotHaveFlag(argument, flag);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -194,7 +194,7 @@
                 if (EnumInfo<T>.HasFlag(value, flag))
                 {
                     var m = message?.Invoke(value, flag) ?? Messages.EnumDoesNotHaveFlag(argument, flag);
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 

--- a/src/Guard.Equality.cs
+++ b/src/Guard.Equality.cs
@@ -30,7 +30,7 @@
             if (!EqualityComparer<T>.Default.Equals(argument.Value, default))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Default(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -64,7 +64,7 @@
                 if (!EqualityComparer<T>.Default.Equals(value, default))
                 {
                     var m = message?.Invoke(value) ?? Messages.Default(argument);
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -94,7 +94,7 @@
             if (EqualityComparer<T>.Default.Equals(argument.Value, default))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NotDefault(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -122,7 +122,7 @@
             if (EqualityComparer<T>.Default.Equals(argument.Value, default))
             {
                 var m = message ?? Messages.NotDefault(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -153,7 +153,7 @@
                 if (EqualityComparer<T>.Default.Equals(value, default))
                 {
                     var m = message ?? Messages.NotDefault(argument);
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -206,7 +206,7 @@
             if (argument.HasValue() && !(comparer ?? EqualityComparer<T>.Default).Equals(argument.Value, other))
             {
                 var m = message?.Invoke(argument.Value, other) ?? Messages.Equal(argument, other);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -262,7 +262,7 @@
             if (argument.HasValue() && (comparer ?? EqualityComparer<T>.Default).Equals(argument.Value, other))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NotEqual(argument, other);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -290,7 +290,7 @@
             if (argument.HasValue() && !ReferenceEquals(argument.Value, other))
             {
                 var m = message?.Invoke(argument.Value, other) ?? Messages.Same(argument, other);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -320,7 +320,7 @@
             if (argument.HasValue() && ReferenceEquals(argument.Value, other))
             {
                 var m = message?.Invoke(argument.Value, other) ?? Messages.NotSame(argument, other);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;

--- a/src/Guard.IComparable.cs
+++ b/src/Guard.IComparable.cs
@@ -37,9 +37,9 @@
             if (argument.HasValue() && Comparer<T>.Default.Compare(argument.Value, minValue) < 0)
             {
                 var m = message?.Invoke(argument.Value, minValue) ?? Messages.Min(argument, minValue);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -78,9 +78,9 @@
                 if (argument.HasValue() && Comparer<T>.Default.Compare(value, minValue) < 0)
                 {
                     var m = message?.Invoke(value, minValue) ?? Messages.Min(argument, minValue);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                          ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                         : new ArgumentException(m, argument.Name);
+                         : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -116,9 +116,9 @@
             if (argument.HasValue() && Comparer<T>.Default.Compare(argument.Value, maxValue) > 0)
             {
                 var m = message?.Invoke(argument.Value, maxValue) ?? Messages.Max(argument, maxValue);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -157,9 +157,9 @@
                 if (argument.HasValue() && Comparer<T>.Default.Compare(value, maxValue) > 0)
                 {
                     var m = message?.Invoke(value, maxValue) ?? Messages.Max(argument, maxValue);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                          ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                         : new ArgumentException(m, argument.Name);
+                         : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -201,9 +201,9 @@
                     comparer.Compare(argument.Value, maxValue) > 0)
                 {
                     var m = message?.Invoke(argument.Value, minValue, maxValue) ?? Messages.InRange(argument, minValue, maxValue);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -250,9 +250,9 @@
                         comparer.Compare(value, maxValue) > 0)
                     {
                         var m = message?.Invoke(value, minValue, maxValue) ?? Messages.InRange(argument, minValue, maxValue);
-                        throw !argument.Modified
+                        throw argument.Exception(!argument.Modified
                             ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                            : new ArgumentException(m, argument.Name);
+                            : new ArgumentException(m, argument.Name));
                     }
                 }
             }
@@ -285,9 +285,9 @@
             if (Comparer<T>.Default.Compare(argument.Value, default) != 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Zero(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -329,9 +329,9 @@
                 if (Comparer<T>.Default.Compare(value, default) != 0)
                 {
                     var m = message?.Invoke(value) ?? Messages.Zero(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                          ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                         : new ArgumentException(m, argument.Name);
+                         : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -363,9 +363,9 @@
             if (Comparer<T>.Default.Compare(argument.Value, default) == 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NotZero(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -395,9 +395,9 @@
             if (Comparer<T>.Default.Compare(argument.Value, default) == 0)
             {
                 var m = message ?? Messages.NotZero(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -436,9 +436,9 @@
             if (argument.NotNull(out var a) && Comparer<T>.Default.Compare(a.Value, default) == 0)
             {
                 var m = message?.Invoke(a.Value) ?? Messages.NotZero(a);
-                throw !a.Modified
+                throw argument.Exception(!a.Modified
                      ? new ArgumentOutOfRangeException(a.Name, argument.Secure ? null : a.Value as object, m)
-                     : new ArgumentException(m, a.Name);
+                     : new ArgumentException(m, a.Name));
             }
 
             return ref argument;
@@ -479,9 +479,9 @@
                 if (Comparer<T>.Default.Compare(value, default) == 0)
                 {
                     var m = message ?? Messages.NotZero(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                          ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                         : new ArgumentException(m, argument.Name);
+                         : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -514,9 +514,9 @@
             if (Comparer<T>.Default.Compare(argument.Value, default) <= 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Positive(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -559,9 +559,9 @@
                 if (Comparer<T>.Default.Compare(value, default) <= 0)
                 {
                     var m = message?.Invoke(value) ?? Messages.Positive(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                          ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                         : new ArgumentException(m, argument.Name);
+                         : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -594,9 +594,9 @@
             if (Comparer<T>.Default.Compare(argument.Value, default) > 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NotPositive(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -639,9 +639,9 @@
                 if (Comparer<T>.Default.Compare(value, default) > 0)
                 {
                     var m = message?.Invoke(value) ?? Messages.NotPositive(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                          ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                         : new ArgumentException(m, argument.Name);
+                         : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -674,9 +674,9 @@
             if (Comparer<T>.Default.Compare(argument.Value, default) >= 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Negative(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -719,9 +719,9 @@
                 if (Comparer<T>.Default.Compare(value, default) >= 0)
                 {
                     var m = message?.Invoke(value) ?? Messages.Negative(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                          ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                         : new ArgumentException(m, argument.Name);
+                         : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -754,9 +754,9 @@
             if (Comparer<T>.Default.Compare(argument.Value, default) < 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NotNegative(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                      ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                     : new ArgumentException(m, argument.Name);
+                     : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -799,9 +799,9 @@
                 if (Comparer<T>.Default.Compare(value, default) < 0)
                 {
                     var m = message?.Invoke(value) ?? Messages.NotNegative(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                          ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                         : new ArgumentException(m, argument.Name);
+                         : new ArgumentException(m, argument.Name));
                 }
             }
 

--- a/src/Guard.IEnumerable.cs
+++ b/src/Guard.IEnumerable.cs
@@ -35,7 +35,7 @@
             if (argument.HasValue() && Collection<TCollection>.Count(argument.Value, 1) != 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.CollectionEmpty(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -62,7 +62,7 @@
             if (argument.HasValue() && Collection<TCollection>.Count(argument.Value, 1) == 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.CollectionNotEmpty(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -95,7 +95,7 @@
             if (argument.HasValue() && Collection<TCollection>.Count(argument.Value, minCount) < minCount)
             {
                 var m = message?.Invoke(argument.Value, minCount) ?? Messages.CollectionMinCount(argument, minCount);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -128,7 +128,7 @@
             if (argument.HasValue() && Collection<TCollection>.Count(argument.Value, maxCount + 1) > maxCount)
             {
                 var m = message?.Invoke(argument.Value, maxCount) ?? Messages.CollectionMaxCount(argument, maxCount);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -170,7 +170,7 @@
                     var m = message?.Invoke(argument.Value, minCount, maxCount)
                         ?? Messages.CollectionCountInRange(argument, minCount, maxCount);
 
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -231,7 +231,7 @@
             if (argument.HasValue() && !Collection<TCollection>.Typed<TItem>.Contains(argument.Value, item, comparer))
             {
                 var m = message?.Invoke(argument.Value, item) ?? Messages.CollectionContains(argument, item);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -289,7 +289,7 @@
             if (argument.HasValue() && Collection<TCollection>.Typed<TItem>.Contains(argument.Value, item, comparer))
             {
                 var m = message?.Invoke(argument.Value, item) ?? Messages.CollectionDoesNotContain(argument, item);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -318,7 +318,7 @@
             if (argument.HasValue() && !Collection<TCollection>.ContainsNull(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.CollectionContains(argument, "null");
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -345,7 +345,7 @@
             if (argument.HasValue() && Collection<TCollection>.ContainsNull(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.CollectionDoesNotContain(argument, "null");
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -411,7 +411,7 @@
                 var m = message?.Invoke(argument.Value, collection)
                     ?? Messages.InCollection(argument, collection);
 
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -439,7 +439,7 @@
                         return ref argument;
 
                 var m = Messages.InCollection(argument, items);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -505,7 +505,7 @@
                 var m = message?.Invoke(argument.Value, collection)
                     ?? Messages.NotInCollection(argument, collection);
 
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -532,7 +532,7 @@
                     if (comparer.Equals(argument.Value, items[i]))
                     {
                         var m = Messages.NotInCollection(argument, items);
-                        throw new ArgumentException(m, argument.Name);
+                        throw argument.Exception(new ArgumentException(m, argument.Name));
                     }
             }
 

--- a/src/Guard.Member.cs
+++ b/src/Guard.Member.cs
@@ -46,7 +46,7 @@
         /// <param name="member">An expression that specifies the argument member to validate.</param>
         /// <param name="validation">The function to test the argument member against.</param>
         /// <param name="validatesRange">
-        ///     Pass <c>true</c> to throw an <see cref="ArgumentOutOfRangeException" /> instead of an
+        ///     Pass <c>true</c> to throw argument.Exception(an <see cref="ArgumentOutOfRangeException" /> instead of an
         ///     <see cref="ArgumentException" /> if the precondition is not satisfied.
         /// </param>
         /// <param name="message">
@@ -84,7 +84,7 @@
                 }
                 catch (ArgumentException ex)
                 {
-                    throw new ArgumentException(ex.Message, nameof(member), ex);
+                    throw argument.Exception(new ArgumentException(ex.Message, nameof(member), ex));
                 }
 
                 // Get member value.
@@ -96,7 +96,7 @@
                 catch (Exception ex)
                 {
                     var m = $"{argument.Name}.{member.Name} cannot be retrieved.";
-                    throw new ArgumentException(m, nameof(member), ex);
+                    throw argument.Exception(new ArgumentException(m, nameof(member), ex));
                 }
 
                 // Validate the member.
@@ -108,9 +108,9 @@
                 catch (Exception ex)
                 {
                     var m = message?.Invoke(argument.Value, memberValue, ex) ?? ex.Message;
-                    throw !validatesRange || argument.Modified
+                    throw argument.Exception(!validatesRange || argument.Modified
                         ? new ArgumentException(m, argument.Name, ex)
-                        : new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m);
+                        : new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m));
                 }
             }
 
@@ -152,7 +152,7 @@
         /// <param name="member">An expression that specifies the argument member to validate.</param>
         /// <param name="validation">The function to test the argument member against.</param>
         /// <param name="validatesRange">
-        ///     Pass <c>true</c> to throw an <see cref="ArgumentOutOfRangeException" /> instead of an
+        ///     Pass <c>true</c> to throw argument.Exception(an <see cref="ArgumentOutOfRangeException" /> instead of an
         ///     <see cref="ArgumentException" /> if the precondition is not satisfied.
         /// </param>
         /// <param name="message">
@@ -191,7 +191,7 @@
                 }
                 catch (ArgumentException ex)
                 {
-                    throw new ArgumentException(ex.Message, nameof(member), ex);
+                    throw argument.Exception(new ArgumentException(ex.Message, nameof(member), ex));
                 }
 
                 // Get member value.
@@ -203,7 +203,7 @@
                 catch (Exception ex)
                 {
                     var m = $"{argument.Name}.{member.Name} cannot be retrieved.";
-                    throw new ArgumentException(m, nameof(member), ex);
+                    throw argument.Exception(new ArgumentException(m, nameof(member), ex));
                 }
 
                 // Validate the member.
@@ -215,9 +215,9 @@
                 catch (Exception ex)
                 {
                     var m = message?.Invoke(argument.Value.Value, memberValue, ex) ?? ex.Message;
-                    throw !validatesRange || argument.Modified
+                    throw argument.Exception(!validatesRange || argument.Modified
                         ? new ArgumentException(m, argument.Name, ex)
-                        : new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m);
+                        : new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m));
                 }
             }
 

--- a/src/Guard.Modify.cs
+++ b/src/Guard.Modify.cs
@@ -17,7 +17,7 @@
         [GuardFunction("Normalization", "gmod")]
         public static ArgumentInfo<TTarget> Modify<TSource, TTarget>(
             in this ArgumentInfo<TSource> argument, TTarget value)
-            => new ArgumentInfo<TTarget>(value, argument.Name, true, argument.Secure);
+            => new ArgumentInfo<TTarget>(value, argument.Name, true, argument.Secure, argument.ExceptionInterceptor);
 
         /// <summary>
         ///     Returns a new argument with the same name and a value that is created using the
@@ -40,7 +40,7 @@
         {
             Argument(convert, nameof(convert)).NotNull();
             return new ArgumentInfo<TTarget>(
-                convert(argument.Value), argument.Name, true, argument.Secure);
+                convert(argument.Value), argument.Name, true, argument.Secure, argument.ExceptionInterceptor);
         }
 
         /// <summary>
@@ -78,12 +78,12 @@
             try
             {
                 return new ArgumentInfo<TTarget>(
-                    convert(argument.Value), argument.Name, true, argument.Secure);
+                    convert(argument.Value), argument.Name, true, argument.Secure,argument.ExceptionInterceptor);
             }
             catch (Exception x)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Require(argument);
-                throw new ArgumentException(m, argument.Name, x);
+                throw argument.Exception(new ArgumentException(m, argument.Name, x));
             }
         }
 
@@ -104,7 +104,7 @@
                 return argument;
 
             return new ArgumentInfo<T>(
-                argument.Value.Clone() as T, argument.Name, argument.Modified, argument.Secure);
+                argument.Value.Clone() as T, argument.Name, argument.Modified, argument.Secure,argument.ExceptionInterceptor);
         }
 
 #endif

--- a/src/Guard.Null.cs
+++ b/src/Guard.Null.cs
@@ -28,7 +28,7 @@
             if (argument.HasValue())
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Null(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -60,7 +60,7 @@
             {
                 Debug.Assert(argument.Value.HasValue, "argument.HasValue");
                 var m = message?.Invoke(argument.Value.Value) ?? Messages.Null(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -92,9 +92,9 @@
             if (!argument.HasValue())
             {
                 var m = message ?? Messages.NotNull(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentNullException(argument.Name, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -126,13 +126,13 @@
             if (!argument.HasValue())
             {
                 var m = message ?? Messages.NotNull(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentNullException(argument.Name, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return new ArgumentInfo<T>(
-                argument.Value.Value, argument.Name, argument.Modified, argument.Secure);
+                argument.Value.Value, argument.Name, argument.Modified, argument.Secure,argument.ExceptionInterceptor);
         }
 
         /// <summary>
@@ -157,7 +157,7 @@
             if (argument.HasValue())
             {
                 result = new ArgumentInfo<T>(
-                    argument.Value.Value, argument.Name, argument.Modified, argument.Secure);
+                    argument.Value.Value, argument.Name, argument.Modified, argument.Secure,argument.ExceptionInterceptor);
 
                 return true;
             }

--- a/src/Guard.Require.cs
+++ b/src/Guard.Require.cs
@@ -31,7 +31,7 @@
             ///     exception if the condition is not met.
             /// </summary>
             /// <typeparam name="TException">
-            ///     The type of the exception to throw if the argument does not satisfy the specified condition.
+            ///     The type of the exception to throw argument.Exception(if the argument does not satisfy the specified condition.
             /// </typeparam>
             /// <param name="condition">Whether the precondition is satisfied.</param>
             /// <param name="message">
@@ -54,7 +54,7 @@
                 if (this.HasValue() && !condition)
                 {
                     var m = message?.Invoke(this.Value) ?? Messages.Require(this);
-                    throw Exception<TException>.Factory(this.Name, m);
+                    throw this.Exception(Exception<TException>.Factory(this.Name, m));
                 }
 
                 return this;
@@ -81,7 +81,7 @@
             ///     exception if the condition is not met.
             /// </summary>
             /// <typeparam name="TException">
-            ///     The type of the exception to throw if the argument does not satisfy the specified condition.
+            ///     The type of the exception to throw argument.Exception(if the argument does not satisfy the specified condition.
             /// </typeparam>
             /// <param name="predicate">The function to test the argument value.</param>
             /// <param name="message">
@@ -103,7 +103,7 @@
                 if (this.HasValue() && predicate?.Invoke(this.Value) == false)
                 {
                     var m = message?.Invoke(this.Value) ?? Messages.Require(this);
-                    throw Exception<TException>.Factory(this.Name, m);
+                    throw this.Exception(Exception<TException>.Factory(this.Name, m));
                 }
 
                 return this;

--- a/src/Guard.Single.cs
+++ b/src/Guard.Single.cs
@@ -34,9 +34,9 @@
             if (!float.IsNaN(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NaN(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -78,9 +78,9 @@
                 if (!float.IsNaN(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.NaN(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -113,9 +113,9 @@
             if (float.IsNaN(argument.Value))
             {
                 var m = message ?? Messages.NotNaN(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -150,9 +150,9 @@
                 if (float.IsNaN(value))
                 {
                     var m = message ?? Messages.NotNaN(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -187,9 +187,9 @@
             if (!float.IsInfinity(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Infinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -234,9 +234,9 @@
                 if (!float.IsInfinity(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.Infinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -269,9 +269,9 @@
             if (float.IsInfinity(argument.Value))
             {
                 var m = message ?? Messages.NotInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -304,9 +304,9 @@
             if (float.IsInfinity(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NotInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -338,9 +338,9 @@
             if (argument.NotNull(out var a) && float.IsInfinity(a.Value))
             {
                 var m = message ?? Messages.NotInfinity(a);
-                throw !a.Modified
+                throw argument.Exception(!a.Modified
                     ? new ArgumentOutOfRangeException(a.Name, argument.Secure ? null : a.Value as object, m)
-                    : new ArgumentException(m, a.Name);
+                    : new ArgumentException(m, a.Name));
             }
 
             return ref argument;
@@ -382,9 +382,9 @@
                 if (float.IsInfinity(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.NotInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -418,9 +418,9 @@
             if (!float.IsPositiveInfinity(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.PositiveInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -462,9 +462,9 @@
                 if (!float.IsPositiveInfinity(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.PositiveInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -497,9 +497,9 @@
             if (float.IsPositiveInfinity(argument.Value))
             {
                 var m = message ?? Messages.NotPositiveInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -534,9 +534,9 @@
                 if (float.IsPositiveInfinity(value))
                 {
                     var m = message ?? Messages.NotPositiveInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -570,9 +570,9 @@
             if (!float.IsNegativeInfinity(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NegativeInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -614,9 +614,9 @@
                 if (!float.IsNegativeInfinity(value))
                 {
                     var m = message?.Invoke(value) ?? Messages.NegativeInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -649,9 +649,9 @@
             if (float.IsNegativeInfinity(argument.Value))
             {
                 var m = message ?? Messages.NotNegativeInfinity(argument);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -686,9 +686,9 @@
                 if (float.IsNegativeInfinity(value))
                 {
                     var m = message ?? Messages.NotNegativeInfinity(argument);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -724,9 +724,9 @@
             if (diff > delta)
             {
                 var m = message?.Invoke(argument.Value, other) ?? Messages.Equal(argument, other, delta);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -764,9 +764,9 @@
                 if (diff > delta)
                 {
                     var m = message?.Invoke(value, other) ?? Messages.Equal(argument, other, delta);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -802,9 +802,9 @@
             if (diff <= delta)
             {
                 var m = message?.Invoke(argument.Value, other) ?? Messages.NotEqual(argument, other, delta);
-                throw !argument.Modified
+                throw argument.Exception(!argument.Modified
                     ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : argument.Value as object, m)
-                    : new ArgumentException(m, argument.Name);
+                    : new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -842,9 +842,9 @@
                 if (diff <= delta)
                 {
                     var m = message?.Invoke(value, other) ?? Messages.NotEqual(argument, other, delta);
-                    throw !argument.Modified
+                    throw argument.Exception(!argument.Modified
                         ? new ArgumentOutOfRangeException(argument.Name, argument.Secure ? null : value as object, m)
-                        : new ArgumentException(m, argument.Name);
+                        : new ArgumentException(m, argument.Name));
                 }
             }
 

--- a/src/Guard.String.cs
+++ b/src/Guard.String.cs
@@ -29,7 +29,7 @@
             if (argument.Value?.Length > 0)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.StringEmpty(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -54,7 +54,7 @@
             if (argument.Value?.Length == 0)
             {
                 var m = message ?? Messages.StringNotEmpty(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -82,7 +82,7 @@
             if (argument.Value != null && !string.IsNullOrWhiteSpace(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.StringWhiteSpace(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -111,7 +111,7 @@
             if (argument.Value != null && string.IsNullOrWhiteSpace(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.StringNotWhiteSpace(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -146,7 +146,7 @@
             if (argument.Value?.Length < minLength)
             {
                 var m = message?.Invoke(argument.Value, minLength) ?? Messages.StringMinLength(argument, minLength);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -180,7 +180,7 @@
             if (argument.Value?.Length > maxLength)
             {
                 var m = message?.Invoke(argument.Value, maxLength) ?? Messages.StringMaxLength(argument, maxLength);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -221,7 +221,7 @@
                     var m = message?.Invoke(argument.Value, minLength, maxLength)
                         ?? Messages.StringLengthInRange(argument, minLength, maxLength);
 
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
 
             return ref argument;
@@ -255,7 +255,7 @@
             if (argument.HasValue() && !StringEqualityComparer(comparison).Equals(argument.Value, other))
             {
                 var m = message?.Invoke(argument.Value, other) ?? Messages.Equal(argument, other);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -289,7 +289,7 @@
             if (argument.HasValue() && StringEqualityComparer(comparison).Equals(argument.Value, other))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.NotEqual(argument, other);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -347,7 +347,7 @@
             if (argument.HasValue() && value != null && !argument.Value.StartsWith(value, comparison))
             {
                 var m = message?.Invoke(argument.Value, value) ?? Messages.StringStartsWith(argument, value);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -405,7 +405,7 @@
             if (argument.HasValue() && value != null && argument.Value.StartsWith(value, comparison))
             {
                 var m = message?.Invoke(argument.Value, value) ?? Messages.StringDoesNotStartWith(argument, value);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -463,7 +463,7 @@
             if (argument.HasValue() && value != null && !argument.Value.EndsWith(value, comparison))
             {
                 var m = message?.Invoke(argument.Value, value) ?? Messages.StringEndsWith(argument, value);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -521,7 +521,7 @@
             if (argument.HasValue() && value != null && argument.Value.EndsWith(value, comparison))
             {
                 var m = message?.Invoke(argument.Value, value) ?? Messages.StringDoesNotEndWith(argument, value);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -560,7 +560,7 @@
                 catch (ArgumentException ex)
                 {
                     // ParamName of the ArgumentException thrown by IsMatch is null.
-                    throw new ArgumentException(ex.Message, nameof(pattern), ex);
+                    throw argument.Exception(new ArgumentException(ex.Message, nameof(pattern), ex));
                 }
 
                 if (!matches)
@@ -568,7 +568,7 @@
                     var m = message?.Invoke(argument.Value, false)
                         ?? Messages.StringMatches(argument, pattern);
 
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -616,14 +616,14 @@
                 catch (ArgumentException ex)
                 {
                     // ParamName of the ArgumentException thrown by IsMatch is null.
-                    throw new ArgumentException(ex.Message, nameof(pattern), ex);
+                    throw argument.Exception(new ArgumentException(ex.Message, nameof(pattern), ex));
                 }
                 catch (RegexMatchTimeoutException ex)
                 {
                     var m = message?.Invoke(argument.Value, true)
                         ?? Messages.StringMatchesTimeout(argument, pattern, matchTimeout);
 
-                    throw new ArgumentException(m, argument.Name, ex);
+                    throw argument.Exception(new ArgumentException(m, argument.Name, ex));
                 }
 
                 if (!matches)
@@ -631,7 +631,7 @@
                     var m = message?.Invoke(argument.Value, false)
                         ?? Messages.StringMatches(argument, pattern);
 
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -673,7 +673,7 @@
                     var m = message?.Invoke(argument.Value, true)
                         ?? Messages.StringMatchesTimeout(argument, regex.ToString(), ex.MatchTimeout);
 
-                    throw new ArgumentException(m, argument.Name, ex);
+                    throw argument.Exception(new ArgumentException(m, argument.Name, ex));
                 }
 
                 if (!matches)
@@ -681,7 +681,7 @@
                     var m = message?.Invoke(argument.Value, false)
                         ?? Messages.StringMatches(argument, regex.ToString());
 
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -722,7 +722,7 @@
                 catch (ArgumentException ex)
                 {
                     // ParamName of the ArgumentException thrown by IsMatch is null.
-                    throw new ArgumentException(ex.Message, nameof(pattern), ex);
+                    throw argument.Exception(new ArgumentException(ex.Message, nameof(pattern), ex));
                 }
 
                 if (matches)
@@ -730,7 +730,7 @@
                     var m = message?.Invoke(argument.Value, false)
                         ?? Messages.StringDoesNotMatch(argument, pattern);
 
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -779,14 +779,14 @@
                 catch (ArgumentException ex)
                 {
                     // ParamName of the ArgumentException thrown by IsMatch is null.
-                    throw new ArgumentException(ex.Message, nameof(pattern), ex);
+                    throw argument.Exception(new ArgumentException(ex.Message, nameof(pattern), ex));
                 }
                 catch (RegexMatchTimeoutException ex)
                 {
                     var m = message?.Invoke(argument.Value, true)
                         ?? Messages.StringDoesNotMatchTimeout(argument, pattern, matchTimeout);
 
-                    throw new ArgumentException(m, argument.Name, ex);
+                    throw argument.Exception(new ArgumentException(m, argument.Name, ex));
                 }
 
                 if (matches)
@@ -794,7 +794,7 @@
                     var m = message?.Invoke(argument.Value, false)
                         ?? Messages.StringDoesNotMatch(argument, pattern);
 
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -837,7 +837,7 @@
                     var m = message?.Invoke(argument.Value, true)
                         ?? Messages.StringDoesNotMatchTimeout(argument, regex.ToString(), ex.MatchTimeout);
 
-                    throw new ArgumentException(m, argument.Name, ex);
+                    throw argument.Exception(new ArgumentException(m, argument.Name, ex));
                 }
 
                 if (matches)
@@ -845,7 +845,7 @@
                     var m = message?.Invoke(argument.Value, false)
                         ?? Messages.StringDoesNotMatch(argument, regex.ToString());
 
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 

--- a/src/Guard.Types.cs
+++ b/src/Guard.Types.cs
@@ -34,11 +34,11 @@
             if (!TypeInfo<T>.CanBeInitializedFrom(argument.Value))
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.Type(argument, typeof(T));
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return new ArgumentInfo<T>(
-                (T)argument.Value, argument.Name, argument.Modified, argument.Secure);
+                (T)argument.Value, argument.Name, argument.Modified, argument.Secure,argument.ExceptionInterceptor);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@
             if (argument.HasValue() && TypeInfo<T>.CanBeInitializedFrom(argument.Value))
             {
                 var m = message?.Invoke((T)argument.Value) ?? Messages.NotType(argument, typeof(T));
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -94,7 +94,7 @@
             if (argument.HasValue() && !TypeInfo.CanBeConvertedTo(argument.Value, type))
             {
                 var m = message?.Invoke(argument.Value, type) ?? Messages.Type(argument, type);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -124,7 +124,7 @@
             if (argument.HasValue() && TypeInfo.CanBeConvertedTo(argument.Value, type))
             {
                 var m = message?.Invoke(argument.Value, type) ?? Messages.NotType(argument, type);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -157,7 +157,7 @@
                     return this;
 
                 var m = message?.Invoke(this.Value) ?? Messages.Compatible<T, TTarget>(this);
-                throw new ArgumentException(m, this.Name);
+                throw this.Exception(new ArgumentException(m, this.Name));
             }
 
             /// <summary>
@@ -183,7 +183,7 @@
                 if (this.HasValue() && this.Value is TTarget value)
                 {
                     var m = message?.Invoke(value) ?? Messages.NotCompatible<T, TTarget>(this);
-                    throw new ArgumentException(m, this.Name);
+                    throw this.Exception(new ArgumentException(m, this.Name));
                 }
 
                 return this;
@@ -213,10 +213,10 @@
             public ArgumentInfo<TTarget> Cast<TTarget>(Func<T, string> message = null)
             {
                 if (this.Value is TTarget value)
-                    return new ArgumentInfo<TTarget>(value, this.Name, this.Modified, this.Secure);
+                    return new ArgumentInfo<TTarget>(value, this.Name, this.Modified, this.Secure,this.ExceptionInterceptor);
 
                 var m = message?.Invoke(this.Value) ?? Messages.Compatible<T, TTarget>(this);
-                throw new ArgumentException(m, this.Name);
+                throw this.Exception(new ArgumentException(m, this.Name));
             }
         }
 

--- a/src/Guard.Uri.cs
+++ b/src/Guard.Uri.cs
@@ -33,7 +33,7 @@
             if (argument.HasValue() && !argument.Value.IsAbsoluteUri)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.UriAbsolute(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -58,7 +58,7 @@
             if (argument.HasValue() && argument.Value.IsAbsoluteUri)
             {
                 var m = message?.Invoke(argument.Value) ?? Messages.UriRelative(argument);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -90,7 +90,7 @@
                     !argument.Value.Scheme.Equals(scheme, StringComparison.OrdinalIgnoreCase))
                 {
                     var m = message?.Invoke(argument.Value, scheme) ?? Messages.UriScheme(argument, scheme);
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
             }
 
@@ -119,7 +119,7 @@
                 argument.Value.Scheme.Equals(scheme, StringComparison.OrdinalIgnoreCase))
             {
                 var m = message?.Invoke(argument.Value, scheme) ?? Messages.UriNotScheme(argument, scheme);
-                throw new ArgumentException(m, argument.Name);
+                throw argument.Exception(new ArgumentException(m, argument.Name));
             }
 
             return ref argument;
@@ -182,7 +182,7 @@
             }
 
             var m = message?.Invoke(argument.Value) ?? Messages.UriHttp(argument);
-            throw new ArgumentException(m, argument.Name);
+            throw argument.Exception(new ArgumentException(m, argument.Name));
         }
 
         /// <summary>Requires the argument value to be an absolute URI with the HTTPS scheme.</summary>
@@ -205,7 +205,7 @@
                 if (!argument.Value.IsAbsoluteUri || argument.Value.Scheme != HttpsUriScheme)
                 {
                     var m = message?.Invoke(argument.Value) ?? Messages.UriHttps(argument);
-                    throw new ArgumentException(m, argument.Name);
+                    throw argument.Exception(new ArgumentException(m, argument.Name));
                 }
 
             return ref argument;

--- a/tests/InterceptorBasicTests.cs
+++ b/tests/InterceptorBasicTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Xunit;
+
+namespace Dawn.Tests
+{
+    public class InterceptorBasicTests : BaseTests
+    {
+        [Theory(DisplayName = "Intercept test")]
+        [InlineData("A")]
+        public void Intercept(string argument)
+        {
+            var intercepted = false;
+            Exception interceptedException = null;
+
+            var emptyArg = Guard.Argument(
+                () => argument,
+                exceptionInterceptor: (ex) =>
+                 {
+                     intercepted = true;
+                     interceptedException = ex;
+                 });
+
+            var exception = Assert.Throws<ArgumentException>(() => emptyArg.Empty());
+            Assert.True(intercepted);
+            Assert.Equal(exception, interceptedException);
+        }
+
+        [Theory(DisplayName = "No exception")]
+        [InlineData("")]
+        public void NoException(string argument)
+        {
+            var intercepted = false;
+            Exception interceptedException = null;
+
+            var emptyArg = Guard.Argument(
+                () => argument,
+                exceptionInterceptor: (ex) =>
+                {
+                    intercepted = true;
+                    interceptedException = ex;
+                });
+
+            Assert.False(intercepted);
+            Assert.Null(interceptedException);
+        }
+
+        [Theory(DisplayName = "Modified argument info test")]
+        [InlineData("A")]
+        public void Modified(string argument)
+        {
+            var intercepted = false;
+            Exception interceptedException = null;
+
+            var emptyArg = Guard.Argument(
+                () => argument,
+                exceptionInterceptor: (ex) =>
+                {
+                    intercepted = true;
+                    interceptedException = ex;
+                });
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                emptyArg
+                    .NotEmpty()
+                    .Modify(s => "")
+                    .NotEmpty()
+                    );
+
+            Assert.True(intercepted);
+            Assert.Equal(exception, interceptedException);
+        }
+
+        [Theory(DisplayName = "No interceptor test")]
+        [InlineData("A")]
+        public void NoInterceptor(string argument)
+        {
+            var emptyArg = Guard.Argument(
+                () => argument,
+                exceptionInterceptor: null);
+
+            var exception = Assert.Throws<ArgumentException>(() => emptyArg.Empty());
+        }
+
+        [Theory(DisplayName = "Exception in interceptor test")]
+        [InlineData("A")]
+        public void ExceptionInInterceptor(string argument)
+        {
+            var emptyArg = Guard.Argument(
+                () => argument,
+                exceptionInterceptor: (ex) =>
+            {
+                throw new InvalidOperationException();
+            });
+
+            //When the interceptor fails, its exception is thrown instead of the Guard exception (it's not "hidded" by design)
+            var exception = Assert.Throws<InvalidOperationException>(() => emptyArg.Empty());
+        }
+    }
+}


### PR DESCRIPTION
Proposal of functionality extension - to extend the ArgumentInfo with the ability to keep the reference to exception interceptor and call such interceptor before the exception is thrown when defined.
Details in related issue ticket https://github.com/safakgur/guard/issues/21