### PR TITLE
using new StackTrace(1, true).ToString() instead of  Environment.StackTrace while invoking the interceptor in Guard.Fail()

### DIFF
--- a/src/Guard.Argument.cs
+++ b/src/Guard.Argument.cs
@@ -72,7 +72,7 @@
 #if !NETSTANDARD1_0
             for (var scope = Scope.Current; scope != null; scope = scope.Parent)
             {
-                scope.ExceptionInterceptor?.Invoke(exception, Environment.StackTrace);
+                scope.ExceptionInterceptor?.Invoke(exception, new StackTrace(1, true).ToString());
                 if (!scope.Propagates)
                     break;
             }


### PR DESCRIPTION
Detail in issue [comment](https://github.com/safakgur/guard/issues/21#issuecomment-451693090)