### PR TITLE
IfDebug method

### DIFF
--- a/src/Guard.Debug.cs
+++ b/src/Guard.Debug.cs
@@ -1,0 +1,19 @@
+﻿using System.Diagnostics;
+
+namespace Dawn
+{
+    public static partial class Guard
+    {
+        /// <summary>
+        ///     Works similar to #if DEBUG directive.
+        ///     The whole method and its argument is ignored in release build configuration.
+        ///     Example Guard.IfDebug(Guard.Argument(age, nameof(age)).NotNegative())
+        /// </summary>
+        /// <param name="validation">
+        ///     Argument validation chain which will be only executed if DEBUG symbol is defined.
+        /// </param>
+        [DebuggerStepThrough]
+        [Conditional("DEBUG")]
+        public static void IfDebug(object validation) { }
+    }
+}


### PR DESCRIPTION
Motivation:
Very often developers avoid guard methods for additional performance
overhead. In other cases, they are afraid to affect legacy code
behaviour - additional exceptions may cause unpredictable side effects in
production environment. Obvoius solution is to use #if DEBUG directives.
However, this solution has two big downsides - it is just ugly and it
excludes code inside these directives from any code validation in
release build configuration.
Solution:
C# comliler has a special attribute ConditionalAttribute. It allows
conditional executeion of a method, and if leads to conditional
execution of arguments of this method. Thus, it is possible to make
the whole statement ignored in production build, such method call will not
even be presented in compiled binaries.
Note:
It does not look reasonable to add unit tests for this method due to the
nature of this method. Such unit tests will require execution of both
debug and release builds of these unit tests.